### PR TITLE
fix: Fix panic due to std::time::Instant::now() on wasm

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ bincode = "1.3"
 rand = "0.8"
 bitfield-rle = "0.2"
 parking_lot = "0.11"
+instant = "0.1"
 
 [dev-dependencies]
 serial_test = "0.5"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,9 @@ bitfield-rle = "0.2"
 parking_lot = "0.11"
 instant = "0.1"
 
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+js-sys = "0.3"
+
 [dev-dependencies]
 serial_test = "0.5"
 piston = "0.53"

--- a/examples/rapier/rapier_synctest.rs
+++ b/examples/rapier/rapier_synctest.rs
@@ -1,6 +1,6 @@
 extern crate freetype as ft;
 
-use std::time::Instant;
+use instant::Instant;
 
 use glutin_window::GlutinWindow as Window;
 use opengl_graphics::{GlGraphics, OpenGL};

--- a/src/network/udp_protocol.rs
+++ b/src/network/udp_protocol.rs
@@ -11,12 +11,13 @@ use crate::sessions::p2p_session::{
 use crate::time_sync::TimeSync;
 use crate::{Frame, PlayerHandle, NULL_FRAME};
 
+use instant::{Duration, Instant};
 use std::collections::vec_deque::Drain;
 use std::collections::VecDeque;
 use std::convert::TryFrom;
 use std::net::SocketAddr;
 use std::ops::Add;
-use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
+use std::time::{SystemTime, UNIX_EPOCH};
 
 use super::network_stats::NetworkStats;
 

--- a/src/network/udp_protocol.rs
+++ b/src/network/udp_protocol.rs
@@ -17,7 +17,6 @@ use std::collections::VecDeque;
 use std::convert::TryFrom;
 use std::net::SocketAddr;
 use std::ops::Add;
-use std::time::{SystemTime, UNIX_EPOCH};
 
 use super::network_stats::NetworkStats;
 
@@ -32,10 +31,17 @@ const QUALITY_REPORT_INTERVAL: Duration = Duration::from_millis(200);
 const MAX_PAYLOAD: usize = 467; // 512 is max safe UDP payload, minus 45 bytes for the rest of the packet
 
 fn millis_since_epoch() -> u128 {
-    SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .expect("Time went backwards")
-        .as_millis()
+    #[cfg(not(target_arch = "wasm32"))]
+    {
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .expect("Time went backwards")
+            .as_millis()
+    }
+    #[cfg(target_arch = "wasm32")]
+    {
+        js_sys::Date::new_0().get_time() as u128
+    }
 }
 
 #[derive(Debug, PartialEq, Eq)]


### PR DESCRIPTION
Calling std::time::Instant::now() causes a panic on wasm.

The instant crate tries to emulate std::time::Instant on wasm, and is a
type alias to std::time::Instant otherwise.