### PR TITLE
refactor: Turn NonBlockingSocket into trait to allow alternate socket types

### DIFF
--- a/src/network/non_blocking_socket/mod.rs
+++ b/src/network/non_blocking_socket/mod.rs
@@ -1,0 +1,11 @@
+use crate::network::udp_msg::UdpMessage;
+use std::net::SocketAddr;
+
+mod udp_socket;
+
+pub(crate) use udp_socket::UdpNonBlockingSocket;
+
+pub(crate) trait NonBlockingSocket: std::fmt::Debug + Send + Sync {
+    fn send_to(&self, msg: &UdpMessage, addr: SocketAddr);
+    fn receive_all_messages(&mut self) -> Vec<(SocketAddr, UdpMessage)>;
+}

--- a/src/network/non_blocking_socket/udp_socket.rs
+++ b/src/network/non_blocking_socket/udp_socket.rs
@@ -1,16 +1,21 @@
+use std::{
+    io::ErrorKind,
+    net::{SocketAddr, ToSocketAddrs, UdpSocket},
+};
+
 use crate::network::udp_msg::UdpMessage;
-use std::io::ErrorKind;
-use std::net::{SocketAddr, ToSocketAddrs, UdpSocket};
+
+use super::NonBlockingSocket;
 
 const RECV_BUFFER_SIZE: usize = 4096;
 
 #[derive(Debug)]
-pub(crate) struct NonBlockingSocket {
+pub(crate) struct UdpNonBlockingSocket {
     socket: UdpSocket,
     buffer: [u8; RECV_BUFFER_SIZE],
 }
 
-impl NonBlockingSocket {
+impl UdpNonBlockingSocket {
     pub(crate) fn new<A: ToSocketAddrs>(addr: A) -> Result<Self, std::io::Error> {
         let socket = UdpSocket::bind(addr)?;
         socket.set_nonblocking(true)?;
@@ -19,13 +24,15 @@ impl NonBlockingSocket {
             buffer: [0; RECV_BUFFER_SIZE],
         })
     }
+}
 
-    pub(crate) fn send_to<A: ToSocketAddrs>(&self, msg: &UdpMessage, addr: A) {
+impl NonBlockingSocket for UdpNonBlockingSocket {
+    fn send_to(&self, msg: &UdpMessage, addr: SocketAddr) {
         let buf = bincode::serialize(&msg).unwrap();
         self.socket.send_to(&buf, addr).unwrap();
     }
 
-    pub(crate) fn receive_all_messages(&mut self) -> Vec<(SocketAddr, UdpMessage)> {
+    fn receive_all_messages(&mut self) -> Vec<(SocketAddr, UdpMessage)> {
         let mut received_messages = Vec::new();
         loop {
             match self.socket.recv_from(&mut self.buffer) {

--- a/src/network/udp_protocol.rs
+++ b/src/network/udp_protocol.rs
@@ -1,10 +1,10 @@
 use crate::frame_info::{GameInput, BLANK_INPUT};
 use crate::network::compression::{decode, encode};
+use crate::network::non_blocking_socket::NonBlockingSocket;
 use crate::network::udp_msg::{
     ConnectionStatus, Input, InputAck, MessageBody, MessageHeader, QualityReply, QualityReport,
     SyncReply, SyncRequest, UdpMessage,
 };
-use crate::network::udp_socket::NonBlockingSocket;
 use crate::sessions::p2p_session::{
     Event, DEFAULT_DISCONNECT_NOTIFY_START, DEFAULT_DISCONNECT_TIMEOUT, DEFAULT_FPS,
 };
@@ -342,7 +342,7 @@ impl UdpProtocol {
      *  SENDING MESSAGES
      */
 
-    pub(crate) fn send_all_messages(&mut self, socket: &NonBlockingSocket) {
+    pub(crate) fn send_all_messages(&mut self, socket: &Box<dyn NonBlockingSocket>) {
         if self.state == ProtocolState::Shutdown {
             self.send_queue.drain(..);
             return;


### PR DESCRIPTION
The session constructors now accept a boxed existing NonBlockingSocket object instead of creating sockets themselves.