### PR TITLE
refactor!: Rename start_*_session functions to new_*_session

### DIFF
--- a/examples/box_game/box_game_p2p.rs
+++ b/examples/box_game/box_game_p2p.rs
@@ -36,7 +36,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     assert!(num_players > 0);
 
     // create a GGRS session
-    let mut sess = ggrs::start_p2p_session(num_players as u32, INPUT_SIZE, opt.local_port)?;
+    let mut sess = ggrs::new_p2p_session(num_players as u32, INPUT_SIZE, opt.local_port)?;
 
     // turn on sparse saving
     sess.set_sparse_saving(true)?;

--- a/examples/box_game/box_game_spectator.rs
+++ b/examples/box_game/box_game_spectator.rs
@@ -33,7 +33,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let opt = Opt::from_args();
 
     // create a GGRS session for a spectator
-    let mut sess = ggrs::start_p2p_spectator_session(
+    let mut sess = ggrs::new_p2p_spectator_session(
         opt.num_players as u32,
         INPUT_SIZE,
         opt.local_port,

--- a/examples/box_game/box_game_synctest.rs
+++ b/examples/box_game/box_game_synctest.rs
@@ -30,7 +30,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // create a GGRS session
     let mut sess =
-        ggrs::start_synctest_session(opt.num_players as u32, INPUT_SIZE, opt.check_distance)?;
+        ggrs::new_synctest_session(opt.num_players as u32, INPUT_SIZE, opt.check_distance)?;
 
     // set input delay for any player you want
     for i in 0..opt.num_players {

--- a/examples/rapier/rapier_synctest.rs
+++ b/examples/rapier/rapier_synctest.rs
@@ -32,8 +32,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let opt = Opt::from_args();
 
     // create a GGRS session
-    let mut sess =
-        ggrs::start_synctest_session(num_players as u32, INPUT_SIZE, opt.check_distance)?;
+    let mut sess = ggrs::new_synctest_session(num_players as u32, INPUT_SIZE, opt.check_distance)?;
 
     // set input delay for any player you want
     for i in 0..num_players {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -144,7 +144,7 @@ pub enum GGRSRequest {
 /// let check_distance : u32 = 7;
 /// let num_players : u32 = 2;
 /// let input_size : usize = std::mem::size_of::<u32>();
-/// let mut sess = ggrs::start_synctest_session(num_players, input_size, check_distance)?;
+/// let mut sess = ggrs::new_synctest_session(num_players, input_size, check_distance)?;
 /// # Ok(())
 /// # }
 /// ```
@@ -153,7 +153,7 @@ pub enum GGRSRequest {
 /// - Will return a `InvalidRequestError` if the number of players is higher than the allowed maximum (see `MAX_PLAYERS`).
 /// - Will return a `InvalidRequestError` if `input_size` is higher than the allowed maximum (see `MAX_INPUT_BYTES`).
 /// - Will return a `InvalidRequestError` if the `check_distance is` higher than or equal to `MAX_PREDICTION_FRAMES`.
-pub fn start_synctest_session(
+pub fn new_synctest_session(
     num_players: u32,
     input_size: usize,
     check_distance: u32,
@@ -190,7 +190,7 @@ pub fn start_synctest_session(
 /// let local_port: u16 = 7777;
 /// let num_players : u32 = 2;
 /// let input_size : usize = std::mem::size_of::<u32>();
-/// let mut sess = ggrs::start_p2p_session(num_players, input_size, local_port)?;
+/// let mut sess = ggrs::new_p2p_session(num_players, input_size, local_port)?;
 /// # Ok(())
 /// # }
 /// ```
@@ -201,7 +201,7 @@ pub fn start_synctest_session(
 /// - Will return a `InvalidRequest` if the number of players is higher than the allowed maximum (see `MAX_PLAYERS`).
 /// - Will return a `InvalidRequest` if `input_size` is higher than the allowed maximum (see `MAX_INPUT_BYTES`).
 /// - Will return `SocketCreationFailed` if the socket could not be created.
-pub fn start_p2p_session(
+pub fn new_p2p_session(
     num_players: u32,
     input_size: usize,
     local_port: u16,
@@ -231,7 +231,7 @@ pub fn start_p2p_session(
 /// # Errors
 /// - Will return a `InvalidRequest` if the number of players is higher than the allowed maximum (see `MAX_PLAYERS`).
 /// - Will return a `InvalidRequest` if `input_size` is higher than the allowed maximum (see `MAX_INPUT_BYTES`).
-pub fn start_p2p_session_with_socket(
+pub fn new_p2p_session_with_socket(
     num_players: u32,
     input_size: usize,
     socket: impl NonBlockingSocket + 'static,
@@ -261,7 +261,7 @@ pub fn start_p2p_session_with_socket(
 /// let num_players : u32 = 2;
 /// let input_size : usize = std::mem::size_of::<u32>();
 /// let host_addr: SocketAddr = "127.0.0.1:8888".parse()?;
-/// let mut sess = ggrs::start_p2p_spectator_session(num_players, input_size, local_port, host_addr)?;
+/// let mut sess = ggrs::new_p2p_spectator_session(num_players, input_size, local_port, host_addr)?;
 /// # Ok(())
 /// # }
 /// ```
@@ -272,7 +272,7 @@ pub fn start_p2p_session_with_socket(
 /// - Will return a `InvalidRequest` if the number of players is higher than the allowed maximum (see `MAX_PLAYERS`).
 /// - Will return a `InvalidRequest` if `input_size` is higher than the allowed maximum (see `MAX_INPUT_BYTES`).
 /// - Will return `SocketCreationFailed` if the socket could not be created.
-pub fn start_p2p_spectator_session(
+pub fn new_p2p_spectator_session(
     num_players: u32,
     input_size: usize,
     local_port: u16,
@@ -309,7 +309,7 @@ pub fn start_p2p_spectator_session(
 /// # Errors
 /// - Will return a `InvalidRequest` if the number of players is higher than the allowed maximum (see `MAX_PLAYERS`).
 /// - Will return a `InvalidRequest` if `input_size` is higher than the allowed maximum (see `MAX_INPUT_BYTES`).
-pub fn start_p2p_spectator_session_with_socket(
+pub fn new_p2p_spectator_session_with_socket(
     num_players: u32,
     input_size: usize,
     socket: impl NonBlockingSocket + 'static,

--- a/tests/test_p2p_session.rs
+++ b/tests/test_p2p_session.rs
@@ -8,13 +8,13 @@ mod stubs;
 #[test]
 #[serial]
 fn test_create_session() {
-    assert!(ggrs::start_p2p_session(2, stubs::INPUT_SIZE, 7777).is_ok());
+    assert!(ggrs::new_p2p_session(2, stubs::INPUT_SIZE, 7777).is_ok());
 }
 
 #[test]
 #[serial]
 fn test_add_player() {
-    let mut sess = ggrs::start_p2p_session(2, stubs::INPUT_SIZE, 7777).unwrap();
+    let mut sess = ggrs::new_p2p_session(2, stubs::INPUT_SIZE, 7777).unwrap();
     let addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 8080);
     assert!(sess.add_player(PlayerType::Local, 0).is_ok());
     assert!(sess.add_player(PlayerType::Remote(addr), 1).is_ok());
@@ -29,7 +29,7 @@ fn test_add_player() {
 #[test]
 #[serial]
 fn test_start_session() {
-    let mut sess = ggrs::start_p2p_session(2, stubs::INPUT_SIZE, 7777).unwrap();
+    let mut sess = ggrs::new_p2p_session(2, stubs::INPUT_SIZE, 7777).unwrap();
     let addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 8080);
     assert!(sess.add_player(ggrs::PlayerType::Local, 0).is_ok());
     assert!(sess.start_session().is_err()); // not enough players
@@ -41,7 +41,7 @@ fn test_start_session() {
 #[test]
 #[serial]
 fn test_disconnect_player() {
-    let mut sess = ggrs::start_p2p_session(2, stubs::INPUT_SIZE, 7777).unwrap();
+    let mut sess = ggrs::new_p2p_session(2, stubs::INPUT_SIZE, 7777).unwrap();
     let addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 8080);
     assert!(sess.add_player(ggrs::PlayerType::Local, 0).is_ok());
     assert!(sess.add_player(ggrs::PlayerType::Remote(addr), 1).is_ok());
@@ -54,8 +54,8 @@ fn test_disconnect_player() {
 #[test]
 #[serial]
 fn test_synchronize_p2p_sessions() {
-    let mut sess1 = ggrs::start_p2p_session(2, stubs::INPUT_SIZE, 7777).unwrap();
-    let mut sess2 = ggrs::start_p2p_session(2, stubs::INPUT_SIZE, 8888).unwrap();
+    let mut sess1 = ggrs::new_p2p_session(2, stubs::INPUT_SIZE, 7777).unwrap();
+    let mut sess2 = ggrs::new_p2p_session(2, stubs::INPUT_SIZE, 8888).unwrap();
     let addr1 = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 7777);
     let addr2 = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 8888);
 
@@ -87,8 +87,8 @@ fn test_synchronize_p2p_sessions() {
 fn test_advance_frame_p2p_sessions() {
     let mut stub1 = stubs::GameStub::new();
     let mut stub2 = stubs::GameStub::new();
-    let mut sess1 = ggrs::start_p2p_session(2, stubs::INPUT_SIZE, 7777).unwrap();
-    let mut sess2 = ggrs::start_p2p_session(2, stubs::INPUT_SIZE, 8888).unwrap();
+    let mut sess1 = ggrs::new_p2p_session(2, stubs::INPUT_SIZE, 7777).unwrap();
+    let mut sess2 = ggrs::new_p2p_session(2, stubs::INPUT_SIZE, 8888).unwrap();
     let addr1 = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 7777);
     let addr2 = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 8888);
 

--- a/tests/test_p2p_spectator_session.rs
+++ b/tests/test_p2p_spectator_session.rs
@@ -9,7 +9,7 @@ mod stubs;
 #[serial]
 fn test_create_session() {
     let host_addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 7777);
-    assert!(ggrs::start_p2p_spectator_session(1, stubs::INPUT_SIZE, 9999, host_addr).is_ok());
+    assert!(ggrs::new_p2p_spectator_session(1, stubs::INPUT_SIZE, 9999, host_addr).is_ok());
 }
 
 #[test]
@@ -17,7 +17,7 @@ fn test_create_session() {
 fn test_start_session() {
     let host_addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 7777);
     let mut spec_sess =
-        ggrs::start_p2p_spectator_session(1, stubs::INPUT_SIZE, 9999, host_addr).unwrap();
+        ggrs::new_p2p_spectator_session(1, stubs::INPUT_SIZE, 9999, host_addr).unwrap();
     assert!(spec_sess.start_session().is_ok());
     assert!(spec_sess.current_state() == SessionState::Synchronizing);
 }
@@ -28,9 +28,9 @@ fn test_synchronize_with_host() {
     let host_addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 7777);
     let spec_addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 8888);
 
-    let mut host_sess = ggrs::start_p2p_session(1, stubs::INPUT_SIZE, 7777).unwrap();
+    let mut host_sess = ggrs::new_p2p_session(1, stubs::INPUT_SIZE, 7777).unwrap();
     let mut spec_sess =
-        ggrs::start_p2p_spectator_session(1, stubs::INPUT_SIZE, 8888, host_addr).unwrap();
+        ggrs::new_p2p_spectator_session(1, stubs::INPUT_SIZE, 8888, host_addr).unwrap();
 
     host_sess.add_player(PlayerType::Local, 0).unwrap();
     host_sess

--- a/tests/test_synctest_session.rs
+++ b/tests/test_synctest_session.rs
@@ -4,14 +4,14 @@ mod stubs;
 
 #[test]
 fn test_create_session() {
-    assert!(ggrs::start_synctest_session(2, stubs::INPUT_SIZE, 2).is_ok());
+    assert!(ggrs::new_synctest_session(2, stubs::INPUT_SIZE, 2).is_ok());
 }
 
 #[test]
 fn test_advance_frame_with_rollbacks() {
     let check_distance = 7;
     let mut stub = stubs::GameStub::new();
-    let mut sess = ggrs::start_synctest_session(2, stubs::INPUT_SIZE, check_distance).unwrap();
+    let mut sess = ggrs::new_synctest_session(2, stubs::INPUT_SIZE, check_distance).unwrap();
 
     for i in 0..200 {
         let input: u32 = i;
@@ -29,7 +29,7 @@ fn test_advance_frames_with_delayed_input() {
     let handle = 1;
     let check_distance = 7;
     let mut stub = stubs::GameStub::new();
-    let mut sess = ggrs::start_synctest_session(2, stubs::INPUT_SIZE, check_distance).unwrap();
+    let mut sess = ggrs::new_synctest_session(2, stubs::INPUT_SIZE, check_distance).unwrap();
     assert!(sess.set_frame_delay(2, handle).is_ok());
 
     for i in 0..200 {


### PR DESCRIPTION
The function returns sessions, but they are not in a started state, that
is done later by the `start_session` call, so renaming start to new
should help distinguish the concepts.