### PR TITLE
Made the socket type generic.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,8 +11,9 @@ keywords = ["gamedev", "networking", "ggpo", "rollback"]
 categories = ["network-programming", "game-development"]
 
 [features]
-default = ["sync_test"]
+default = ["send_socket", "sync_test"]
 sync_test = []
+send_socket = []
 
 [dependencies]
 serde = { version = "1.0", features = ["derive"] }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -57,13 +57,13 @@ pub type PlayerHandle = usize;
 /// - spectators, who are remote players that do not contribute to the game input.
 /// Both `Remote` and `Spectator` have a socket address associated with them.
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum PlayerType {
+pub enum PlayerType<A = std::net::SocketAddr> {
     /// This player plays on the local device.
     Local,
     /// This player plays on a remote device identified by the socket address.
-    Remote(std::net::SocketAddr),
+    Remote(A),
     /// This player spectates on a remote device identified by the socket address. They do not contribute to the game input.
-    Spectator(std::net::SocketAddr),
+    Spectator(A),
 }
 
 impl Default for PlayerType {

--- a/src/network/non_blocking_socket/mod.rs
+++ b/src/network/non_blocking_socket/mod.rs
@@ -8,11 +8,18 @@ pub(crate) use udp_socket::UdpNonBlockingSocket;
 /// However you wish to send and receive messages, it should be implemented through these two methods.
 /// Messages should be sent in an UDP-like fashion, unordered and unreliable.
 /// GGRS has an internal protocol on top of this to make sure all important information is sent and received.
-pub trait NonBlockingSocket<A>: std::fmt::Debug {
+/// Disable feature `send_socket` to remove the Send + Sync bounds. Note: bevy_ggrs requires `send_socket` to be enabled.
+#[cfg(feature = "send_socket")]
+pub trait NonBlockingSocket<A>: std::fmt::Debug + Send + Sync {
     /// Takes an `UdpMessage` and sends it to the given address.
     fn send_to(&mut self, msg: &UdpMessage, addr: &A);
 
     /// This method should return all messages received since the last time this method was called. `
     /// The pairs `(A, UdpMessage)` indicate from which address each packet was received.
+    fn receive_all_messages(&mut self) -> Vec<(A, UdpMessage)>;
+}
+#[cfg(not(feature = "send_socket"))]
+pub trait NonBlockingSocket<A>: std::fmt::Debug {
+    fn send_to(&mut self, msg: &UdpMessage, addr: &A);
     fn receive_all_messages(&mut self) -> Vec<(A, UdpMessage)>;
 }

--- a/src/network/non_blocking_socket/mod.rs
+++ b/src/network/non_blocking_socket/mod.rs
@@ -8,7 +8,7 @@ pub(crate) use udp_socket::UdpNonBlockingSocket;
 /// However you wish to send and receive messages, it should be implemented through these two methods.
 /// Messages should be sent in an UDP-like fashion, unordered and unreliable.
 /// GGRS has an internal protocol on top of this to make sure all important information is sent and received.
-pub trait NonBlockingSocket<A>: std::fmt::Debug + Send + Sync {
+pub trait NonBlockingSocket<A>: std::fmt::Debug {
     /// Takes an `UdpMessage` and sends it to the given address.
     fn send_to(&mut self, msg: &UdpMessage, addr: &A);
 

--- a/src/network/non_blocking_socket/mod.rs
+++ b/src/network/non_blocking_socket/mod.rs
@@ -1,5 +1,4 @@
 use crate::network::udp_msg::UdpMessage;
-use std::net::SocketAddr;
 
 mod udp_socket;
 
@@ -9,11 +8,11 @@ pub(crate) use udp_socket::UdpNonBlockingSocket;
 /// However you wish to send and receive messages, it should be implemented through these two methods.
 /// Messages should be sent in an UDP-like fashion, unordered and unreliable.
 /// GGRS has an internal protocol on top of this to make sure all important information is sent and received.
-pub trait NonBlockingSocket: std::fmt::Debug + Send + Sync {
-    /// Takes an `UdpMessage` and sends it to the given `SocketAddr`.
-    fn send_to(&mut self, msg: &UdpMessage, addr: SocketAddr);
+pub trait NonBlockingSocket<A>: std::fmt::Debug + Send + Sync {
+    /// Takes an `UdpMessage` and sends it to the given address.
+    fn send_to(&mut self, msg: &UdpMessage, addr: &A);
 
     /// This method should return all messages received since the last time this method was called. `
-    /// The pairs `(SocketAddr, UdpMessage)` indicate from which adress each packet was received.
-    fn receive_all_messages(&mut self) -> Vec<(SocketAddr, UdpMessage)>;
+    /// The pairs `(A, UdpMessage)` indicate from which address each packet was received.
+    fn receive_all_messages(&mut self) -> Vec<(A, UdpMessage)>;
 }

--- a/src/network/non_blocking_socket/udp_socket.rs
+++ b/src/network/non_blocking_socket/udp_socket.rs
@@ -26,8 +26,8 @@ impl UdpNonBlockingSocket {
     }
 }
 
-impl NonBlockingSocket for UdpNonBlockingSocket {
-    fn send_to(&mut self, msg: &UdpMessage, addr: SocketAddr) {
+impl NonBlockingSocket<SocketAddr> for UdpNonBlockingSocket {
+    fn send_to(&mut self, msg: &UdpMessage, addr: &SocketAddr) {
         let buf = bincode::serialize(&msg).unwrap();
         self.socket.send_to(&buf, addr).unwrap();
     }


### PR DESCRIPTION
This is helpful for cases in which the NonBlockingSockets might not be connecting via IP address (eg. WebRTC where every peer connection is a bit more complex)

I don't think this actually will cause any breaking changes because the type parameter has a default.