### PR TITLE
Fixed faulty test:  sync_layer::test_reach_prediction_threshold()

### DIFF
--- a/src/sync_layer.rs
+++ b/src/sync_layer.rs
@@ -302,6 +302,7 @@ mod sync_layer_tests {
         for i in 0..20 {
             let game_input = PlayerInput::new(i, TestInput { inp: i as u8 });
             sync_layer.add_local_input(0, game_input).unwrap(); // should crash at frame 7
+            sync_layer.advance_frame();
         }
     }
 


### PR DESCRIPTION
it was at first panicking because the input frame didn't match up with the current frame. now it correctly panics when hitting the prediction threshold.