### PR TITLE
Support enum with fields in `Config::Input`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ rand = "0.8"
 bitfield-rle = "0.2"
 parking_lot = "0.11"
 instant = "0.1"
-bytemuck = {version = "1.9", features = ["derive"]}
+bytemuck = {version = "1.12.3", features = ["derive"]}
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 js-sys = "0.3"

--- a/src/init_pad.rs
+++ b/src/init_pad.rs
@@ -1,0 +1,80 @@
+use bytemuck::{AnyBitPattern, Zeroable};
+
+/// Credits to @fu5ha https://github.com/Lokathor/bytemuck/issues/84#issuecomment-1312912158
+
+/// This type adds some `const PAD` number of "explicit" or "manual" padding
+/// bytes to the end of a struct.
+///
+/// This is useful to make a type not have *real* padding bytes,
+/// and therefore be able to be marked as [`bytemuck::NoUninit`]. Specifically,
+/// it's used in the `ffi_union` macro to equalize the size of all
+/// fields of a union and therefore remove any "real" padding bytes from the union, making
+/// it safe to store in WASM memory and pass through the ark module host memory utility functions.
+/// It may also be useful in other places.
+#[derive(Copy, Clone)]
+#[repr(C)]
+pub struct TransparentPad<T, const PAD: usize>(pub T, [u8; PAD]);
+
+// SAFETY: Since `[u8; N]` is always Zeroable, this is safe
+unsafe impl<T: Zeroable, const PAD: usize> Zeroable for TransparentPad<T, PAD> {}
+
+// SAFETY: Since `[u8; N]` is always AnyBitPattern, this is safe
+unsafe impl<T: AnyBitPattern, const PAD: usize> AnyBitPattern for TransparentPad<T, PAD> {}
+
+#[doc(hidden)] // it is only for us in this crate
+#[macro_export]
+macro_rules! impl_checked_bit_pattern_for_transparent_pad {
+    ($inner:ident) => {
+        // SAFETY: The extra padding is always AnyBitPattern, so implies CheckedBitPattern, and this just passes
+        // down the necessary safety checks to the inner type.
+        unsafe impl<const PAD: usize> bytemuck::CheckedBitPattern
+            for $crate::TransparentPad<$inner, PAD>
+        {
+            type Bits = $crate::TransparentPad<<$inner as bytemuck::CheckedBitPattern>::Bits, PAD>;
+
+            fn is_valid_bit_pattern(bits: &Self::Bits) -> bool {
+                <$inner as bytemuck::CheckedBitPattern>::is_valid_bit_pattern(&bits.0)
+            }
+        }
+    };
+}
+
+impl<T, const PAD: usize> TransparentPad<T, PAD> {
+    /// Stores argument value alongside a zero-intialized slice `[u8; N]`
+    pub fn new(inner: T) -> Self {
+        Self(inner, [0u8; PAD])
+    }
+}
+
+impl<T, const PAD: usize> AsRef<T> for TransparentPad<T, PAD> {
+    fn as_ref(&self) -> &T {
+        &self.0
+    }
+}
+
+impl<T, const PAD: usize> AsMut<T> for TransparentPad<T, PAD> {
+    fn as_mut(&mut self) -> &mut T {
+        &mut self.0
+    }
+}
+
+impl<T, const PAD: usize> core::ops::Deref for TransparentPad<T, PAD> {
+    type Target = T;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl<T, const PAD: usize> core::ops::DerefMut for TransparentPad<T, PAD> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
+    }
+}
+
+// Additionnal code
+impl<T: PartialEq, const PAD: usize> PartialEq for TransparentPad<T, PAD> {
+    fn eq(&self, other: &Self) -> bool {
+        self.0 == other.0
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,13 +3,17 @@
 //! The callback-style API from the original library has been replaced with a much saner, simpler control flow.
 //! Instead of registering callback functions, GGRS returns a list of requests for the user to fulfill.
 
-#![forbid(unsafe_code)] // let us try
+// FIXME: commented just to try out a concept of padding for supporting field enum in `Config::Input`.
+// Eventually support should come from bytemuck and we're back to safe code.
+// #![forbid(unsafe_code)] // let us try
+
 #![deny(missing_docs)]
 #![deny(rustdoc::broken_intra_doc_links)]
 //#![warn(clippy::all, clippy::pedantic, clippy::nursery, clippy::cargo)]
 use std::{fmt::Debug, hash::Hash};
 
 pub use error::GGRSError;
+pub use init_pad::TransparentPad;
 pub use network::messages::Message;
 pub use network::network_stats::NetworkStats;
 pub use network::udp_socket::UdpNonBlockingSocket;
@@ -21,6 +25,7 @@ pub use sync_layer::GameStateCell;
 
 pub(crate) mod error;
 pub(crate) mod frame_info;
+pub(crate) mod init_pad;
 pub(crate) mod input_queue;
 pub(crate) mod sync_layer;
 pub(crate) mod time_sync;

--- a/tests/stubs_enum.rs
+++ b/tests/stubs_enum.rs
@@ -2,7 +2,7 @@ use std::collections::hash_map::DefaultHasher;
 use std::hash::{Hash, Hasher};
 use std::net::SocketAddr;
 
-use ggrs::{Config, Frame, GGRSRequest, GameStateCell, InputStatus};
+use ggrs::{Config, Frame, GGRSRequest, GameStateCell, InputStatus, TransparentPad};
 
 fn calculate_hash<T: Hash>(t: &T) -> u64 {
     let mut s = DefaultHasher::new();
@@ -15,16 +15,27 @@ pub struct GameStubEnum {
 }
 use bytemuck::{CheckedBitPattern, NoUninit, Zeroable};
 
-#[repr(u8)]
-#[derive(Copy, Clone, PartialEq, CheckedBitPattern, NoUninit)]
+#[repr(u16)]
+#[derive(Copy, Clone, PartialEq)]
 pub enum EnumInput {
-    Val1,
-    Val2,
+    Val1(u16),
+    Val2(TransparentPad<u8, 8>),
 }
+unsafe impl NoUninit for EnumInput {}
 
 unsafe impl Zeroable for EnumInput {
     fn zeroed() -> Self {
         unsafe { core::mem::zeroed() }
+    }
+}
+
+unsafe impl CheckedBitPattern for EnumInput {
+    type Bits = u32;
+    fn is_valid_bit_pattern(bits: &u32) -> bool {
+        match *bits {
+            0 | 1 | 2 => true,
+            _ => false,
+        }
     }
 }
 

--- a/tests/test_p2p_session_enum.rs
+++ b/tests/test_p2p_session_enum.rs
@@ -1,0 +1,146 @@
+mod stubs_enum;
+
+use ggrs::{GGRSError, PlayerType, SessionBuilder, SessionState, UdpNonBlockingSocket};
+use serial_test::serial;
+use std::net::{IpAddr, Ipv4Addr, SocketAddr};
+use stubs_enum::{EnumInput, StubEnumConfig};
+
+#[test]
+#[serial]
+fn test_add_more_players() -> Result<(), GGRSError> {
+    let socket = UdpNonBlockingSocket::bind_to_port(7777).unwrap();
+    let remote_addr1 = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 8080);
+    let remote_addr2 = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 8081);
+    let remote_addr3 = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 8082);
+    let spec_addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 8090);
+
+    let _sess = SessionBuilder::<StubEnumConfig>::new()
+        .with_num_players(4)
+        .add_player(PlayerType::Local, 0)?
+        .add_player(PlayerType::Remote(remote_addr1), 1)?
+        .add_player(PlayerType::Remote(remote_addr2), 2)?
+        .add_player(PlayerType::Remote(remote_addr3), 3)?
+        .add_player(PlayerType::Spectator(spec_addr), 4)?
+        .start_p2p_session(socket)?;
+    Ok(())
+}
+
+#[test]
+#[serial]
+fn test_start_session() -> Result<(), GGRSError> {
+    let socket = UdpNonBlockingSocket::bind_to_port(7777).unwrap();
+    let remote_addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 8080);
+    let spec_addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 8090);
+
+    let _sess = SessionBuilder::<StubEnumConfig>::new()
+        .add_player(PlayerType::Local, 0)?
+        .add_player(PlayerType::Remote(remote_addr), 1)?
+        .add_player(PlayerType::Spectator(spec_addr), 2)?
+        .start_p2p_session(socket)?;
+    Ok(())
+}
+
+#[test]
+#[serial]
+fn test_disconnect_player() -> Result<(), GGRSError> {
+    let socket = UdpNonBlockingSocket::bind_to_port(7777).unwrap();
+    let remote_addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 8080);
+    let spec_addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 8090);
+
+    let mut sess = SessionBuilder::<StubEnumConfig>::new()
+        .add_player(PlayerType::Local, 0)?
+        .add_player(PlayerType::Remote(remote_addr), 1)?
+        .add_player(PlayerType::Spectator(spec_addr), 2)?
+        .start_p2p_session(socket)?;
+
+    assert!(sess.disconnect_player(5).is_err()); // invalid handle
+    assert!(sess.disconnect_player(0).is_err()); // for now, local players cannot be disconnected
+    assert!(sess.disconnect_player(1).is_ok());
+    assert!(sess.disconnect_player(1).is_err()); // already disconnected
+    assert!(sess.disconnect_player(2).is_ok());
+
+    Ok(())
+}
+
+#[test]
+#[serial]
+fn test_synchronize_p2p_sessions() -> Result<(), GGRSError> {
+    let addr1 = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 7777);
+    let addr2 = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 8888);
+
+    let socket1 = UdpNonBlockingSocket::bind_to_port(7777).unwrap();
+    let mut sess1 = SessionBuilder::<StubEnumConfig>::new()
+        .add_player(PlayerType::Local, 0)?
+        .add_player(PlayerType::Remote(addr2), 1)?
+        .start_p2p_session(socket1)?;
+
+    let socket2 = UdpNonBlockingSocket::bind_to_port(8888).unwrap();
+    let mut sess2 = SessionBuilder::<StubEnumConfig>::new()
+        .add_player(PlayerType::Local, 1)?
+        .add_player(PlayerType::Remote(addr1), 0)?
+        .start_p2p_session(socket2)?;
+
+    assert!(sess1.current_state() == SessionState::Synchronizing);
+    assert!(sess2.current_state() == SessionState::Synchronizing);
+
+    for _ in 0..50 {
+        sess1.poll_remote_clients();
+        sess2.poll_remote_clients();
+    }
+
+    assert!(sess1.current_state() == SessionState::Running);
+    assert!(sess2.current_state() == SessionState::Running);
+
+    Ok(())
+}
+
+#[test]
+#[serial]
+fn test_advance_frame_p2p_sessions() -> Result<(), GGRSError> {
+    let addr1 = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 7777);
+    let addr2 = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 8888);
+
+    let socket1 = UdpNonBlockingSocket::bind_to_port(7777).unwrap();
+    let mut sess1 = SessionBuilder::<StubEnumConfig>::new()
+        .add_player(PlayerType::Local, 0)?
+        .add_player(PlayerType::Remote(addr2), 1)?
+        .start_p2p_session(socket1)?;
+
+    let socket2 = UdpNonBlockingSocket::bind_to_port(8888).unwrap();
+    let mut sess2 = SessionBuilder::<StubEnumConfig>::new()
+        .add_player(PlayerType::Remote(addr1), 0)?
+        .add_player(PlayerType::Local, 1)?
+        .start_p2p_session(socket2)?;
+
+    assert!(sess1.current_state() == SessionState::Synchronizing);
+    assert!(sess2.current_state() == SessionState::Synchronizing);
+
+    for _ in 0..50 {
+        sess1.poll_remote_clients();
+        sess2.poll_remote_clients();
+    }
+
+    assert!(sess1.current_state() == SessionState::Running);
+    assert!(sess2.current_state() == SessionState::Running);
+
+    let mut stub1 = stubs_enum::GameStubEnum::new();
+    let mut stub2 = stubs_enum::GameStubEnum::new();
+    let reps = 10;
+    for i in 0..reps {
+        sess1.poll_remote_clients();
+        sess2.poll_remote_clients();
+
+        sess1.add_local_input(0, EnumInput::Val1(i)).unwrap();
+        let requests1 = sess1.advance_frame().unwrap();
+        stub1.handle_requests(requests1);
+        sess2.add_local_input(1, EnumInput::Val1(i)).unwrap();
+        let requests2 = sess2.advance_frame().unwrap();
+        stub2.handle_requests(requests2);
+
+        // gamestate evolves
+        assert_eq!(stub1.gs.frame, i as i32 + 1);
+        assert_eq!(stub2.gs.frame, i as i32 + 1);
+    }
+
+    Ok(())
+}

--- a/tests/test_synctest_session_enum.rs
+++ b/tests/test_synctest_session_enum.rs
@@ -1,6 +1,6 @@
 mod stubs_enum;
 
-use ggrs::{GGRSError, SessionBuilder};
+use ggrs::{GGRSError, SessionBuilder, TransparentPad};
 
 #[test]
 fn test_enum_advance_frames_with_delayed_input() -> Result<(), GGRSError> {
@@ -11,7 +11,10 @@ fn test_enum_advance_frames_with_delayed_input() -> Result<(), GGRSError> {
         .with_input_delay(2)
         .start_synctest_session()?;
 
-    let inputs = [stubs_enum::EnumInput::Val1, stubs_enum::EnumInput::Val2];
+    let inputs = [
+        stubs_enum::EnumInput::Val1(16),
+        stubs_enum::EnumInput::Val2(TransparentPad::new(8)),
+    ];
     for i in 0..200 {
         let input = inputs[i % inputs.len()];
         sess.add_local_input(0, input)?;


### PR DESCRIPTION
Fix https://github.com/gschup/ggrs/issues/40.

Follow up to https://github.com/gschup/ggrs/pull/41.

Currently just hacking stuff together, I dropped `forbid_unsafe` for my tests ; but ultimately the plan is to upstream that work to bytemuck.

Maybe https://jack.wrenn.fyi/blog/deflect/ contains helpful insights.