### PR TITLE
feat: DesyncDetection For P2PSessions

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -141,6 +141,17 @@ where
         /// Amount of frames recommended to be skipped in order to let other clients catch up.
         skip_frames: u32,
     },
+    /// Sent whenever GGRS locally detected a discrepancy between local and remote checksums
+    DesyncDetected{
+        /// Frame of the checksums
+        frame: Frame,
+        /// local checksum for the given frame
+        local_checksum: u128,
+        /// remote checksum for the given frame
+        remote_checksum: u128,
+        /// remote address of the endpoint.
+        remote_addr: T::Address,
+    }
 }
 
 /// Requests that you can receive from the session. Handling them is mandatory.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -53,6 +53,18 @@ pub type PlayerHandle = usize;
 // #   ENUMS   #
 // #############
 
+/// Desync detection by comparing checksums between peers.
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub enum DesyncDetection {
+    /// Desync detection is turned on with a specified interval rate given by the user.
+    On {
+        /// interval rate given by the user. e.g. at 60hz an interval of 10 results to 6 reports a second.
+        interval: u32,
+    },
+    /// Desync detection is turned off
+    Off,
+}
+
 /// Defines the three types of players that GGRS considers:
 /// - local players, who play on the local device,
 /// - remote players, who play on other devices and
@@ -142,7 +154,7 @@ where
         skip_frames: u32,
     },
     /// Sent whenever GGRS locally detected a discrepancy between local and remote checksums
-    DesyncDetected{
+    DesyncDetected {
         /// Frame of the checksums
         frame: Frame,
         /// local checksum for the given frame
@@ -150,8 +162,8 @@ where
         /// remote checksum for the given frame
         remote_checksum: u128,
         /// remote address of the endpoint.
-        remote_addr: T::Address,
-    }
+        addr: T::Address,
+    },
 }
 
 /// Requests that you can receive from the session. Handling them is mandatory.

--- a/src/network/messages.rs
+++ b/src/network/messages.rs
@@ -73,6 +73,12 @@ pub(crate) struct QualityReply {
 }
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Serialize, Deserialize, Default)]
+pub(crate) struct ChecksumReport {
+    pub checksum: u32, // I dont know what size checksum would be favourable  
+    pub frame: Frame, 
+}
+
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Serialize, Deserialize, Default)]
 pub(crate) struct MessageHeader {
     pub magic: u16,
 }
@@ -85,6 +91,7 @@ pub(crate) enum MessageBody {
     InputAck(InputAck),
     QualityReport(QualityReport),
     QualityReply(QualityReply),
+    ChecksumReport(ChecksumReport),
     KeepAlive,
 }
 
@@ -97,3 +104,5 @@ pub struct Message {
     pub(crate) header: MessageHeader,
     pub(crate) body: MessageBody,
 }
+
+

--- a/src/network/messages.rs
+++ b/src/network/messages.rs
@@ -74,7 +74,7 @@ pub(crate) struct QualityReply {
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Serialize, Deserialize, Default)]
 pub(crate) struct ChecksumReport {
-    pub checksum: u32, // I dont know what size checksum would be favourable  
+    pub checksum: u128,
     pub frame: Frame, 
 }
 

--- a/src/network/protocol.rs
+++ b/src/network/protocol.rs
@@ -11,7 +11,6 @@ use instant::{Duration, Instant};
 use std::collections::vec_deque::Drain;
 use std::collections::{HashMap, HashSet, VecDeque};
 use std::convert::TryFrom;
-use std::hash::{self, Hash};
 use std::ops::Add;
 
 use super::network_stats::NetworkStats;
@@ -25,7 +24,7 @@ const RUNNING_RETRY_INTERVAL: Duration = Duration::from_millis(200);
 const KEEP_ALIVE_INTERVAL: Duration = Duration::from_millis(200);
 const QUALITY_REPORT_INTERVAL: Duration = Duration::from_millis(200);
 const MAX_PAYLOAD: usize = 467; // 512 is max safe UDP payload, minus 45 bytes for the rest of the packet
-const MAX_CHECKSUM_HISTORY_SIZE: usize = 128;
+const MAX_CHECKSUM_HISTORY_SIZE: usize = 32;
 
 fn millis_since_epoch() -> u128 {
     #[cfg(not(target_arch = "wasm32"))]

--- a/src/network/protocol.rs
+++ b/src/network/protocol.rs
@@ -24,7 +24,7 @@ const RUNNING_RETRY_INTERVAL: Duration = Duration::from_millis(200);
 const KEEP_ALIVE_INTERVAL: Duration = Duration::from_millis(200);
 const QUALITY_REPORT_INTERVAL: Duration = Duration::from_millis(200);
 const MAX_PAYLOAD: usize = 467; // 512 is max safe UDP payload, minus 45 bytes for the rest of the packet
-const MAX_CHECKSUM_HISTORY_SIZE: usize = 32;
+pub const MAX_CHECKSUM_HISTORY_SIZE: usize = 32;
 
 fn millis_since_epoch() -> u128 {
     #[cfg(not(target_arch = "wasm32"))]
@@ -710,7 +710,7 @@ impl<T: Config> UdpProtocol<T> {
     /// Upon recveiving a `ChecksumReport`, add it to the checksum history
     fn on_checksum_report(&mut self, body: &ChecksumReport) {
         if self.last_added_checksum_frame < body.frame {
-            while self.checksum_history.len() > MAX_CHECKSUM_HISTORY_SIZE {
+            if self.checksum_history.len() > MAX_CHECKSUM_HISTORY_SIZE {
                 // keep the checksums later than last_added_checksum_frame - max_checksum_size
                 self.checksum_history.retain(|&frame, _| {
                     frame > self.last_added_checksum_frame - MAX_CHECKSUM_HISTORY_SIZE as i32

--- a/src/network/protocol.rs
+++ b/src/network/protocol.rs
@@ -709,16 +709,15 @@ impl<T: Config> UdpProtocol<T> {
 
     /// Upon recveiving a `ChecksumReport`, add it to the checksum history
     fn on_checksum_report(&mut self, body: &ChecksumReport) {
-        while self.checksum_history.len() > MAX_CHECKSUM_HISTORY_SIZE {
-            // keep the checksums later than last_added_checksum_frame - max_checksum_size
-            self.checksum_history
-                .retain(|&frame, _| frame > self.last_added_checksum_frame - MAX_CHECKSUM_HISTORY_SIZE as i32);
-        }
-
         if self.last_added_checksum_frame < body.frame {
+            while self.checksum_history.len() > MAX_CHECKSUM_HISTORY_SIZE {
+                // keep the checksums later than last_added_checksum_frame - max_checksum_size
+                self.checksum_history.retain(|&frame, _| {
+                    frame > self.last_added_checksum_frame - MAX_CHECKSUM_HISTORY_SIZE as i32
+                });
+            }
             self.last_added_checksum_frame = body.frame;
-            self.checksum_history
-                .insert(body.frame, body.checksum);
+            self.checksum_history.insert(body.frame, body.checksum);
         }
     }
 

--- a/src/network/protocol.rs
+++ b/src/network/protocol.rs
@@ -709,14 +709,14 @@ impl<T: Config> UdpProtocol<T> {
 
     /// Upon recveiving a `ChecksumReport`, add it to the checksum history
     fn on_checksum_report(&mut self, body: &ChecksumReport) {
+        while self.checksum_history.len() > MAX_CHECKSUM_HISTORY_SIZE {
+            self.checksum_history.pop_back();
+        }
+        
         if self.last_added_checksum_frame < body.frame {
             self.last_added_checksum_frame = body.frame;
             self.checksum_history
                 .push_front((body.frame, body.checksum));
-        }
-
-        while self.checksum_history.len() > MAX_CHECKSUM_HISTORY_SIZE {
-            self.checksum_history.pop_back();
         }
     }
 

--- a/src/sessions/builder.rs
+++ b/src/sessions/builder.rs
@@ -11,6 +11,7 @@ use super::p2p_spectator_session::SPECTATOR_BUFFER_SIZE;
 
 const DEFAULT_PLAYERS: usize = 2;
 const DEFAULT_SAVE_MODE: bool = false;
+const DEFAULT_DETECTION_MODE: bool = false;
 const DEFAULT_INPUT_DELAY: usize = 0;
 const DEFAULT_DISCONNECT_TIMEOUT: Duration = Duration::from_millis(2000);
 const DEFAULT_DISCONNECT_NOTIFY_START: Duration = Duration::from_millis(500);
@@ -36,6 +37,7 @@ where
     /// FPS defines the expected update frequency of this session.
     fps: usize,
     sparse_saving: bool,
+    desync_detection: bool,
     /// The time until a remote player gets disconnected.
     disconnect_timeout: Duration,
     /// The time until the client will get a notification that a remote player is about to be disconnected.
@@ -63,6 +65,7 @@ impl<T: Config> SessionBuilder<T> {
             max_prediction: DEFAULT_MAX_PREDICTION_FRAMES,
             fps: DEFAULT_FPS,
             sparse_saving: DEFAULT_SAVE_MODE,
+            desync_detection: DEFAULT_DETECTION_MODE,
             disconnect_timeout: DEFAULT_DISCONNECT_TIMEOUT,
             disconnect_notify_start: DEFAULT_DISCONNECT_NOTIFY_START,
             input_delay: DEFAULT_INPUT_DELAY,
@@ -152,6 +155,13 @@ impl<T: Config> SessionBuilder<T> {
     /// takes much more time than advancing the game state.
     pub fn with_sparse_saving_mode(mut self, sparse_saving: bool) -> Self {
         self.sparse_saving = sparse_saving;
+        self
+    }
+
+    /// Sets the desync detection mode. With desync detection, the session will compare checksums for all peers to detect discrepancies / desyncs between peers
+    /// If an desync is found the session will send a DesyncDetected event.
+    pub fn with_desync_detection_mode(mut self, desync_detection: bool) -> Self {
+        self.desync_detection = desync_detection;
         self
     }
 
@@ -282,6 +292,7 @@ impl<T: Config> SessionBuilder<T> {
             Box::new(socket),
             self.player_reg,
             self.sparse_saving,
+            self.desync_detection,
             self.input_delay,
         ))
     }

--- a/src/sessions/builder.rs
+++ b/src/sessions/builder.rs
@@ -4,14 +4,14 @@ use instant::Duration;
 
 use crate::{
     network::protocol::UdpProtocol, sessions::p2p_session::PlayerRegistry, Config, GGRSError,
-    NonBlockingSocket, P2PSession, PlayerHandle, PlayerType, SpectatorSession, SyncTestSession,
+    NonBlockingSocket, P2PSession, PlayerHandle, PlayerType, SpectatorSession, SyncTestSession, DesyncDetection,
 };
 
 use super::p2p_spectator_session::SPECTATOR_BUFFER_SIZE;
 
 const DEFAULT_PLAYERS: usize = 2;
 const DEFAULT_SAVE_MODE: bool = false;
-const DEFAULT_DETECTION_MODE: bool = false;
+const DEFAULT_DETECTION_MODE: DesyncDetection = DesyncDetection::Off;
 const DEFAULT_INPUT_DELAY: usize = 0;
 const DEFAULT_DISCONNECT_TIMEOUT: Duration = Duration::from_millis(2000);
 const DEFAULT_DISCONNECT_NOTIFY_START: Duration = Duration::from_millis(500);
@@ -37,7 +37,7 @@ where
     /// FPS defines the expected update frequency of this session.
     fps: usize,
     sparse_saving: bool,
-    desync_detection: bool,
+    desync_detection: DesyncDetection,
     /// The time until a remote player gets disconnected.
     disconnect_timeout: Duration,
     /// The time until the client will get a notification that a remote player is about to be disconnected.
@@ -159,8 +159,8 @@ impl<T: Config> SessionBuilder<T> {
     }
 
     /// Sets the desync detection mode. With desync detection, the session will compare checksums for all peers to detect discrepancies / desyncs between peers
-    /// If an desync is found the session will send a DesyncDetected event.
-    pub fn with_desync_detection_mode(mut self, desync_detection: bool) -> Self {
+    /// If a desync is found the session will send a DesyncDetected event.
+    pub fn with_desync_detection_mode(mut self, desync_detection: DesyncDetection) -> Self {
         self.desync_detection = desync_detection;
         self
     }

--- a/src/sessions/p2p_session.rs
+++ b/src/sessions/p2p_session.rs
@@ -858,8 +858,8 @@ impl<T: Config> P2PSession<T> {
     }
 
     fn compare_local_checksums_against_peers(&mut self) {
-        let frame_to_check = self.confirmed_frame();
-        if frame_to_check != NULL_FRAME && self.current_frame() % CHECKSUM_REPORT_INTERVAL == 0 {
+        let current = self.current_frame();
+        if current % CHECKSUM_REPORT_INTERVAL == 0 && current > self.max_prediction as i32 {
             for (_, remote) in &self.player_reg.remotes {
                 for (remote_frame, remote_checksum) in remote.checksum_history() {
                     for (local_frame, local_checksum) in &self.checksum_history {

--- a/src/sessions/p2p_session.rs
+++ b/src/sessions/p2p_session.rs
@@ -865,10 +865,6 @@ impl<T: Config> P2PSession<T> {
                     for (local_frame, local_checksum) in &self.checksum_history {
                         // if checksums are equal for the same frame send desync event
                         if *local_frame == *remote_frame && *local_checksum != *remote_checksum {
-                            println!(
-                                "frame: {}, local: {}, remote: {}",
-                                local_frame, local_checksum, remote_checksum
-                            );
                             self.event_queue.push_back(GGRSEvent::DesyncDetected {
                                 frame: *local_frame,
                                 local_checksum: *local_checksum,

--- a/src/sessions/p2p_session.rs
+++ b/src/sessions/p2p_session.rs
@@ -863,10 +863,9 @@ impl<T: Config> P2PSession<T> {
     }
 
     fn compare_local_checksums_against_peers(&mut self) {
-        let current = self.current_frame();
         match self.desync_detection {
             DesyncDetection::On { interval } => {
-                if current % interval as i32 != 0 {
+                if self.current_frame() % interval as i32 != 0 {
                     return;
                 }
 
@@ -890,10 +889,11 @@ impl<T: Config> P2PSession<T> {
     }
 
     fn check_checksum_send_interval(&mut self) {
-        let frame_to_send = self.sync_layer.last_saved_frame() - 1;
-        let current = self.current_frame();
         match self.desync_detection {
             DesyncDetection::On { interval } => {
+                let frame_to_send = self.sync_layer.last_saved_frame() - 1;
+                let current = self.current_frame();
+                
                 if current % interval as i32 == 0 && frame_to_send > self.max_prediction as i32 {
                     let cell = self
                         .sync_layer

--- a/src/sessions/p2p_session.rs
+++ b/src/sessions/p2p_session.rs
@@ -18,7 +18,7 @@ use std::convert::TryInto;
 const RECOMMENDATION_INTERVAL: Frame = 60;
 const MIN_RECOMMENDATION: u32 = 3;
 const MAX_EVENT_QUEUE_SIZE: usize = 100;
-const MAX_CHECKSUM_HISTORY_SIZE: usize = 192;
+const MAX_CHECKSUM_HISTORY_SIZE: usize = 32;
 
 pub(crate) struct PlayerRegistry<T>
 where


### PR DESCRIPTION
These changes refer to #46  

**What has been done**
I found this feature also useful for my personal project.
Currently its sends ChecksumReports at an specified rate to the other peers and whenever a discrepancy is found, it sends a DesyncDetected event to the user with information such as the given frame, mismatched checksums and the remote peer address.

**I seek help in**
Maybe the improvement of any codestyle or patterns .
How should I handle the rate of events? currently it sends an event at every chance it gets if a desync is found.
~~How should I incorporate this so this becomes a feature the user can opt-in for.~~

**How did I test this**
I made 2 builds of the ex_game example one with higher movement speed than the other.
