### PR TITLE
Fix wasm build and add ci check

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -25,3 +25,21 @@ jobs:
         run: cargo doc --verbose
       - name: Check formatting
         run: cargo fmt --check
+
+  check-wasm:
+    name: Check wasm
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install stable wasm toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          target: wasm32-unknown-unknown
+          override: true
+      - name: Run cargo check
+        uses: actions-rs/cargo@v1
+        with:
+          command: check
+          args: --target wasm32-unknown-unknown --features wasm-bindgen

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -27,8 +27,8 @@ jobs:
         run: cargo fmt --check
 
   check-wasm:
-    name: Check wasm
     runs-on: ubuntu-latest
+
     steps:
       - uses: actions/checkout@v2
       - name: Install stable wasm toolchain
@@ -38,7 +38,7 @@ jobs:
           toolchain: stable
           target: wasm32-unknown-unknown
           override: true
-      - name: Run cargo check
+      - name: Check wasm
         uses: actions-rs/cargo@v1
         with:
           command: check

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ categories = ["network-programming", "game-development"]
 
 [features]
 sync-send = []
-wasm-bindgen = ["instant/wasm-bindgen"]
+wasm-bindgen = ["instant/wasm-bindgen", "getrandom/js"]
 
 [dependencies]
 serde = { version = "1.0", features = ["derive"] }
@@ -22,6 +22,7 @@ bitfield-rle = "0.2"
 parking_lot = "0.11"
 instant = "0.1"
 bytemuck = {version = "1.9", features = ["derive"]}
+getrandom = {version = "0.2", optional = true}
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 js-sys = "0.3"


### PR DESCRIPTION
ggrs doesn't currently build for wasm. Adding a check that it doesn't go by unnoticed in the future.

Adapted the setup I use in Matchbox. Not sure if there's a big difference between running on windows contra ubuntu?