### PR TITLE
Fix false positives in remote desync detection

### DIFF
--- a/examples/ex_game/ex_game_p2p.rs
+++ b/examples/ex_game/ex_game_p2p.rs
@@ -41,7 +41,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // create a GGRS session
     let mut sess_build = SessionBuilder::<GGRSConfig>::new()
         .with_num_players(num_players)
-        // (optional) exchange and validate state checsums
+        // (optional) exchange and validate state checksums
         .with_desync_detection_mode(ggrs::DesyncDetection::On { interval: 100 })
         // (optional) set expected update frequency
         .with_fps(FPS as usize)?
@@ -124,7 +124,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         // render the game state
         game.render();
 
-        // wait for the next loop (macroquads wants it so)
+        // wait for the next loop (macroquad wants it so)
         next_frame().await;
     }
 }

--- a/src/network/protocol.rs
+++ b/src/network/protocol.rs
@@ -176,7 +176,6 @@ where
 
     // debug desync
     pub(crate) pending_checksums: VecDeque<(Frame, u128)>,
-    last_added_checksum_frame: Frame,
 }
 
 impl<T: Config> PartialEq for UdpProtocol<T> {
@@ -262,7 +261,6 @@ impl<T: Config> UdpProtocol<T> {
 
             // debug desync
             pending_checksums: VecDeque::new(),
-            last_added_checksum_frame: NULL_FRAME,
         }
     }
 
@@ -710,12 +708,10 @@ impl<T: Config> UdpProtocol<T> {
 
     /// Upon receiving a `ChecksumReport`, add it to the checksum history
     fn on_checksum_report(&mut self, body: &ChecksumReport) {
-        if self.last_added_checksum_frame < body.frame {
-            self.pending_checksums
-                .truncate(MAX_CHECKSUM_HISTORY_SIZE - 1);
-            self.pending_checksums
-                .push_front((body.frame, body.checksum));
-        }
+        self.pending_checksums
+            .truncate(MAX_CHECKSUM_HISTORY_SIZE - 1);
+        self.pending_checksums
+            .push_front((body.frame, body.checksum));
     }
 
     /// Returns the frame of the last received input

--- a/src/sessions/builder.rs
+++ b/src/sessions/builder.rs
@@ -322,6 +322,7 @@ impl<T: Config> SessionBuilder<T> {
             self.disconnect_timeout,
             self.disconnect_notify_start,
             self.fps,
+            DesyncDetection::Off,
         );
         host.synchronize();
         SpectatorSession::new(
@@ -369,6 +370,7 @@ impl<T: Config> SessionBuilder<T> {
             self.disconnect_timeout,
             self.disconnect_notify_start,
             self.fps,
+            self.desync_detection,
         );
         // start the synchronization
         endpoint.synchronize();

--- a/src/sessions/p2p_session.rs
+++ b/src/sessions/p2p_session.rs
@@ -897,6 +897,8 @@ impl<T: Config> P2PSession<T> {
                                     addr: remote.peer_addr(),
                                 });
                             }
+                        } else {
+                            break;
                         }
                     }
                 }

--- a/src/sessions/p2p_session.rs
+++ b/src/sessions/p2p_session.rs
@@ -925,10 +925,10 @@ impl<T: Config> P2PSession<T> {
                     }
 
                     if self.local_checksum_history.len() > MAX_CHECKSUM_HISTORY_SIZE {
-                        // keep the checksums later than current - max_checksum_size
-                        self.local_checksum_history.retain(|&frame, _| {
-                            frame > frame_to_send - MAX_CHECKSUM_HISTORY_SIZE as i32
-                        });
+                        let oldest_frame_to_keep = frame_to_send
+                            - (MAX_CHECKSUM_HISTORY_SIZE as i32 - 1) * interval as i32;
+                        self.local_checksum_history
+                            .retain(|&frame, _| frame >= oldest_frame_to_keep as i32);
                     }
                 }
             }

--- a/src/sessions/p2p_session.rs
+++ b/src/sessions/p2p_session.rs
@@ -914,7 +914,9 @@ impl<T: Config> P2PSession<T> {
                     self.last_sent_checksum_frame + interval as i32
                 };
 
-                if self.sync_layer.last_confirmed_frame() >= frame_to_send {
+                if frame_to_send <= self.sync_layer.last_confirmed_frame()
+                    && frame_to_send < self.sync_layer.last_saved_frame()
+                {
                     let cell = self
                         .sync_layer
                         .saved_state_by_frame(frame_to_send)

--- a/src/sync_layer.rs
+++ b/src/sync_layer.rs
@@ -271,6 +271,11 @@ impl<T: Config> SyncLayer<T> {
     pub(crate) fn last_saved_frame(&self) -> Frame {
         self.last_saved_frame
     }
+
+    /// Returns the latest confirmed frame
+    pub(crate) fn last_confirmed_frame(&self) -> Frame {
+        self.last_confirmed_frame
+    }
 }
 
 // #########

--- a/tests/test_p2p_session.rs
+++ b/tests/test_p2p_session.rs
@@ -186,8 +186,7 @@ fn test_desyncs_detected() -> Result<(), GGRSError> {
     let mut stub2 = stubs::GameStub::new();
 
     // run normally for some frames (past first desync interval)
-    let reps = 110;
-    for i in 0..reps {
+    for i in 0..110 {
         sess1.poll_remote_clients();
         sess2.poll_remote_clients();
 
@@ -206,8 +205,7 @@ fn test_desyncs_detected() -> Result<(), GGRSError> {
     assert_eq!(sess2.events().len(), 0);
 
     // run for some more frames
-    let reps = 100;
-    for _ in 0..reps {
+    for _ in 0..100 {
         sess1.poll_remote_clients();
         sess2.poll_remote_clients();
 
@@ -304,7 +302,7 @@ fn test_desyncs_and_input_delay_no_panic() -> Result<(), GGRSError> {
     let mut stub2 = stubs::GameStub::new();
 
     // run normally for some frames (past first desync interval)
-    for i in 0..110 {
+    for i in 0..150 {
         sess1.poll_remote_clients();
         sess2.poll_remote_clients();
 


### PR DESCRIPTION
Fixes #63 and also fixes a bug that checksums are removed prematurely if the interval is > `MAX_CHECKSUM_HISTORY_SIZE`

Confirmed working with the test case for #63 

Bonus: Remote checksums are now only checked once (removed once verified).