### PR TITLE
Implement `Debug` for `GameStateCell`

### DIFF
--- a/src/sync_layer.rs
+++ b/src/sync_layer.rs
@@ -51,6 +51,16 @@ impl<T: Clone> Clone for GameStateCell<T> {
     }
 }
 
+impl<T: Clone> std::fmt::Debug for GameStateCell<T> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let inner = self.0.lock();
+        f.debug_struct("GameStateCell")
+            .field("frame", &inner.frame)
+            .field("checksum", &inner.checksum)
+            .finish_non_exhaustive()
+    }
+}
+
 #[derive(Clone)]
 pub(crate) struct SavedStates<T: Clone> {
     pub states: Vec<GameStateCell<T>>,


### PR DESCRIPTION
Easily printing a cell's frame and checksum can be very useful when debugging.

Can also be very handy for bevy_ggrs to add some more info to `debug!` tracing levels.