### PR TITLE
Report which frames checksums failed for in synctest sessions

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -21,7 +21,9 @@ pub enum GgrsError {
     /// [`SyncTestSession`]: crate::SyncTestSession
     MismatchedChecksum {
         /// The frame at which the mismatch occurred.
-        frame: Frame,
+        current_frame: Frame,
+        /// The frames with mismatched checksums (one or more)
+        mismatched_frames: Vec<Frame>,
     },
     /// The Session is not synchronized yet. Please start the session and wait a few ms to let the clients synchronize.
     NotSynchronized,
@@ -47,11 +49,14 @@ impl Display for GgrsError {
                     "The session is not yet synchronized with all remote sessions."
                 )
             }
-            GgrsError::MismatchedChecksum { frame } => {
+            GgrsError::MismatchedChecksum {
+                current_frame,
+                mismatched_frames,
+            } => {
                 write!(
                     f,
-                    "Detected checksum mismatch during rollback on frame {}.",
-                    frame
+                    "Detected checksum mismatch during rollback on frame {}, mismatched frames: {:?}",
+                    current_frame, mismatched_frames
                 )
             }
             GgrsError::SpectatorTooFarBehind => {

--- a/src/sessions/sync_test_session.rs
+++ b/src/sessions/sync_test_session.rs
@@ -86,10 +86,11 @@ impl<T: Config> SyncTestSession<T> {
         let mut requests = Vec::new();
 
         // if we advanced far enough into the game do comparisons and rollbacks
-        if self.check_distance > 0 && self.sync_layer.current_frame() > self.check_distance as i32 {
+        let current_frame = self.sync_layer.current_frame();
+        if self.check_distance > 0 && current_frame > self.check_distance as i32 {
             // compare checksums of older frames to our checksum history (where only the first version of any checksum is recorded)
-            for i in 0..=self.check_distance as i32 {
-                let frame_to_check = self.sync_layer.current_frame() - i;
+            let oldest_frame_to_check = current_frame - self.check_distance as Frame;
+            for frame_to_check in oldest_frame_to_check..=current_frame {
                 if !self.checksums_consistent(frame_to_check) {
                     return Err(GgrsError::MismatchedChecksum {
                         frame: frame_to_check,


### PR DESCRIPTION
And also report all mismatched frames, not just the first one.

This makes it much easier to debug desyncs, as it tells you exactly which frame(s) you should look into.

Synctest checksum errors now look like this:

```
Detected checksum mismatch during rollback on frame 308, mismatched frames: [305, 306]
```