### PR TITLE
Refactor: naming conventions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ In this document, all remarkable changes are listed. Not mentioned are smaller c
 
 ## Unreleased
 
+- Rename types with GGRS prefix to match rust naming conventions
+- Removed deprecated `GgrsError` variants
 - `GameStateCell` now implements debug.
 - fixed a bug where checksums of unconfirmed frames were compared during desync detection.
 - You can now trigger a desync manually in the example game by pressing SPACE.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -94,7 +94,7 @@ In this document, all remarkable changes are listed. Not mentioned are smaller c
 
 ## 0.4.2
 
-- users are now allowed to save `None` buffers for a `GGRSRequest::SaveRequest`. This allows users to keep their own state history and load/save more efficiently
+- users are now allowed to save `None` buffers for a `GgrsRequest::SaveRequest`. This allows users to keep their own state history and load/save more efficiently
 - added `num_players()`, `input_size()` getters to all sessions
 
 ## 0.4.1
@@ -117,8 +117,8 @@ In this document, all remarkable changes are listed. Not mentioned are smaller c
 
 ## 0.3.0
 
-- `GGRSError::InvalidRequest` now has an added `info` field to explain the problem in more detail
-- removed unused `GGRSError::GeneralFailure`
+- `GgrsError::InvalidRequest` now has an added `info` field to explain the problem in more detail
+- removed unused `GgrsError::GeneralFailure`
 - removed multiple methods in `SyncTestSession`, as they didn't fulfill any meaningful purpose
 - removed unused sequence number from message header, fixing related issues
 - fixed an issue where out-of-order packets would cause a crash
@@ -152,4 +152,4 @@ In this document, all remarkable changes are listed. Not mentioned are smaller c
 
 ## 0.2.0
 
-- Reworked API: Instead of the user passing a GGRSInterface trait object, GGRS now returns a list of GGRSRequests for the user to fulfill
+- Reworked API: Instead of the user passing a GGRSInterface trait object, GGRS now returns a list of GgrsRequests for the user to fulfill

--- a/examples/ex_game/ex_game.rs
+++ b/examples/ex_game/ex_game.rs
@@ -1,7 +1,7 @@
 use std::net::SocketAddr;
 
 use bytemuck::{Pod, Zeroable};
-use ggrs::{Config, Frame, GGRSRequest, GameStateCell, InputStatus, PlayerHandle, NULL_FRAME};
+use ggrs::{Config, Frame, GgrsRequest, GameStateCell, InputStatus, PlayerHandle, NULL_FRAME};
 use macroquad::prelude::*;
 use serde::{Deserialize, Serialize};
 
@@ -73,12 +73,12 @@ impl Game {
     }
 
     // for each request, call the appropriate function
-    pub fn handle_requests(&mut self, requests: Vec<GGRSRequest<GGRSConfig>>) {
+    pub fn handle_requests(&mut self, requests: Vec<GgrsRequest<GGRSConfig>>) {
         for request in requests {
             match request {
-                GGRSRequest::LoadGameState { cell, .. } => self.load_game_state(cell),
-                GGRSRequest::SaveGameState { cell, frame } => self.save_game_state(cell, frame),
-                GGRSRequest::AdvanceFrame { inputs } => self.advance_frame(inputs),
+                GgrsRequest::LoadGameState { cell, .. } => self.load_game_state(cell),
+                GgrsRequest::SaveGameState { cell, frame } => self.save_game_state(cell, frame),
+                GgrsRequest::AdvanceFrame { inputs } => self.advance_frame(inputs),
             }
         }
     }

--- a/examples/ex_game/ex_game.rs
+++ b/examples/ex_game/ex_game.rs
@@ -1,7 +1,7 @@
 use std::net::SocketAddr;
 
 use bytemuck::{Pod, Zeroable};
-use ggrs::{Config, Frame, GgrsRequest, GameStateCell, InputStatus, PlayerHandle, NULL_FRAME};
+use ggrs::{Config, Frame, GameStateCell, GgrsRequest, InputStatus, PlayerHandle, NULL_FRAME};
 use macroquad::prelude::*;
 use serde::{Deserialize, Serialize};
 

--- a/examples/ex_game/ex_game.rs
+++ b/examples/ex_game/ex_game.rs
@@ -51,7 +51,7 @@ fn fletcher16(data: &[u8]) -> u16 {
     (sum2 << 8) | sum1
 }
 
-// BoxGame will handle rendering, gamestate, inputs and GGRSRequests
+// BoxGame will handle rendering, gamestate, inputs and GgrsRequests
 pub struct Game {
     num_players: usize,
     game_state: State,

--- a/examples/ex_game/ex_game_p2p.rs
+++ b/examples/ex_game/ex_game_p2p.rs
@@ -1,7 +1,7 @@
 mod ex_game;
 
 use ex_game::{GGRSConfig, Game};
-use ggrs::{GGRSError, PlayerType, SessionBuilder, SessionState, UdpNonBlockingSocket};
+use ggrs::{GgrsError, PlayerType, SessionBuilder, SessionState, UdpNonBlockingSocket};
 use instant::{Duration, Instant};
 use macroquad::prelude::*;
 use std::net::SocketAddr;
@@ -112,7 +112,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
                 match sess.advance_frame() {
                     Ok(requests) => game.handle_requests(requests),
-                    Err(GGRSError::PredictionThreshold) => {
+                    Err(GgrsError::PredictionThreshold) => {
                         println!("Frame {} skipped", sess.current_frame())
                     }
 

--- a/examples/ex_game/ex_game_spectator.rs
+++ b/examples/ex_game/ex_game_spectator.rs
@@ -1,7 +1,7 @@
 mod ex_game;
 
 use ex_game::{GGRSConfig, Game};
-use ggrs::{GgrsError, GGRSEvent, SessionBuilder, SessionState, UdpNonBlockingSocket};
+use ggrs::{GgrsError, GgrsEvent, SessionBuilder, SessionState, UdpNonBlockingSocket};
 use instant::{Duration, Instant};
 use macroquad::prelude::*;
 use std::net::SocketAddr;
@@ -59,7 +59,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         // handle GGRS events
         for event in sess.events() {
             println!("Event: {:?}", event);
-            if let GGRSEvent::Disconnected { .. } = event {
+            if let GgrsEvent::Disconnected { .. } = event {
                 println!("Disconnected from host.");
                 return Ok(());
             }

--- a/examples/ex_game/ex_game_spectator.rs
+++ b/examples/ex_game/ex_game_spectator.rs
@@ -1,7 +1,7 @@
 mod ex_game;
 
 use ex_game::{GGRSConfig, Game};
-use ggrs::{GGRSError, GGRSEvent, SessionBuilder, SessionState, UdpNonBlockingSocket};
+use ggrs::{GgrsError, GGRSEvent, SessionBuilder, SessionState, UdpNonBlockingSocket};
 use instant::{Duration, Instant};
 use macroquad::prelude::*;
 use std::net::SocketAddr;
@@ -79,7 +79,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             if sess.current_state() == SessionState::Running {
                 match sess.advance_frame() {
                     Ok(requests) => game.handle_requests(requests),
-                    Err(GGRSError::PredictionThreshold) => {
+                    Err(GgrsError::PredictionThreshold) => {
                         println!(
                             "Frame {} skipped: Waiting for input from host.",
                             game.current_frame()

--- a/src/error.rs
+++ b/src/error.rs
@@ -6,7 +6,7 @@ use crate::Frame;
 
 /// This enum contains all error messages this library can return. Most API functions will generally return a [`Result<(),GgrsError>`].
 ///
-/// [`Result<(),GgrsError>`]: std::result::Result
+/// [`Result<(), GgrsError>`]: std::result::Result
 #[derive(Debug, Clone, PartialEq, Hash)]
 pub enum GgrsError {
     /// When the prediction threshold has been reached, we cannot accept more inputs from the local player.

--- a/src/error.rs
+++ b/src/error.rs
@@ -4,7 +4,7 @@ use std::fmt::Display;
 
 use crate::Frame;
 
-/// This enum contains all error messages this library can return. Most API functions will generally return a [`Result<(),GgrsError>`].
+/// This enum contains all error messages this library can return. Most API functions will generally return a [`Result<(), GgrsError>`].
 ///
 /// [`Result<(), GgrsError>`]: std::result::Result
 #[derive(Debug, Clone, PartialEq, Hash)]

--- a/src/error.rs
+++ b/src/error.rs
@@ -8,7 +8,7 @@ use crate::Frame;
 ///
 /// [`Result<(),GGRSError>`]: std::result::Result
 #[derive(Debug, Clone, PartialEq, Hash)]
-pub enum GGRSError {
+pub enum GgrsError {
     /// When the prediction threshold has been reached, we cannot accept more inputs from the local player.
     PredictionThreshold,
     /// You made an invalid request, usually by using wrong parameters for function calls.
@@ -27,56 +27,41 @@ pub enum GGRSError {
     NotSynchronized,
     /// The spectator got so far behind the host that catching up is impossible.
     SpectatorTooFarBehind,
-    /// Deprecated, will be removed in next major release
-    SocketCreationFailed,
-    /// Deprecated, will be removed in next major release
-    PlayerDisconnected,
-    /// Deprecated, will be removed in next major release
-    DecodingError,
 }
 
-impl Display for GGRSError {
+impl Display for GgrsError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            GGRSError::PredictionThreshold => {
+            GgrsError::PredictionThreshold => {
                 write!(
                     f,
                     "Prediction threshold is reached, cannot proceed without catching up."
                 )
             }
-            GGRSError::InvalidRequest { info } => {
+            GgrsError::InvalidRequest { info } => {
                 write!(f, "Invalid Request: {}", info)
             }
-            GGRSError::NotSynchronized => {
+            GgrsError::NotSynchronized => {
                 write!(
                     f,
                     "The session is not yet synchronized with all remote sessions."
                 )
             }
-            GGRSError::MismatchedChecksum { frame } => {
+            GgrsError::MismatchedChecksum { frame } => {
                 write!(
                     f,
                     "Detected checksum mismatch during rollback on frame {}.",
                     frame
                 )
             }
-            GGRSError::SpectatorTooFarBehind => {
+            GgrsError::SpectatorTooFarBehind => {
                 write!(
                     f,
                     "The spectator got so far behind the host that catching up is impossible."
                 )
             }
-            GGRSError::SocketCreationFailed => {
-                write!(f, "Deprecated, will be removed in next major release.")
-            }
-            GGRSError::PlayerDisconnected => {
-                write!(f, "Deprecated, will be removed in next major release.")
-            }
-            GGRSError::DecodingError => {
-                write!(f, "Deprecated, will be removed in next major release.")
-            }
         }
     }
 }
 
-impl Error for GGRSError {}
+impl Error for GgrsError {}

--- a/src/error.rs
+++ b/src/error.rs
@@ -4,9 +4,9 @@ use std::fmt::Display;
 
 use crate::Frame;
 
-/// This enum contains all error messages this library can return. Most API functions will generally return a [`Result<(),GGRSError>`].
+/// This enum contains all error messages this library can return. Most API functions will generally return a [`Result<(),GgrsError>`].
 ///
-/// [`Result<(),GGRSError>`]: std::result::Result
+/// [`Result<(),GgrsError>`]: std::result::Result
 #[derive(Debug, Clone, PartialEq, Hash)]
 pub enum GgrsError {
     /// When the prediction threshold has been reached, we cannot accept more inputs from the local player.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -167,7 +167,7 @@ where
 }
 
 /// Requests that you can receive from the session. Handling them is mandatory.
-pub enum GGRSRequest<T>
+pub enum GgrsRequest<T>
 where
     T: Config,
 {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -113,7 +113,7 @@ pub enum InputStatus {
 
 /// Notifications that you can receive from the session. Handling them is up to the user.
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
-pub enum GGRSEvent<T>
+pub enum GgrsEvent<T>
 where
     T: Config,
 {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,7 +9,7 @@
 //#![warn(clippy::all, clippy::pedantic, clippy::nursery, clippy::cargo)]
 use std::{fmt::Debug, hash::Hash};
 
-pub use error::GGRSError;
+pub use error::GgrsError;
 pub use network::messages::Message;
 pub use network::network_stats::NetworkStats;
 pub use network::udp_socket::UdpNonBlockingSocket;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -143,7 +143,7 @@ where
         /// The client will be disconnected in this amount of ms.
         disconnect_timeout: u128,
     },
-    /// Sent only after a [`GGRSEvent::NetworkInterrupted`] event, if communication with that player has resumed.
+    /// Sent only after a [`GgrsEvent::NetworkInterrupted`] event, if communication with that player has resumed.
     NetworkResumed {
         /// The address of the endpoint.
         addr: T::Address,

--- a/src/network/protocol.rs
+++ b/src/network/protocol.rs
@@ -6,7 +6,7 @@ use crate::network::messages::{
 };
 use crate::time_sync::TimeSync;
 use crate::{
-    Config, DesyncDetection, Frame, GGRSError, NonBlockingSocket, PlayerHandle, NULL_FRAME,
+    Config, DesyncDetection, Frame, GgrsError, NonBlockingSocket, PlayerHandle, NULL_FRAME,
 };
 
 use instant::{Duration, Instant};
@@ -280,15 +280,15 @@ impl<T: Config> UdpProtocol<T> {
         self.local_frame_advantage = remote_frame - local_frame;
     }
 
-    pub(crate) fn network_stats(&self) -> Result<NetworkStats, GGRSError> {
+    pub(crate) fn network_stats(&self) -> Result<NetworkStats, GgrsError> {
         if self.state != ProtocolState::Synchronizing && self.state != ProtocolState::Running {
-            return Err(GGRSError::NotSynchronized);
+            return Err(GgrsError::NotSynchronized);
         }
 
         let now = millis_since_epoch();
         let seconds = (now - self.stats_start_time) / 1000;
         if seconds == 0 {
-            return Err(GGRSError::NotSynchronized);
+            return Err(GgrsError::NotSynchronized);
         }
 
         let total_bytes_sent = self.bytes_sent + (self.packets_sent * UDP_HEADER_SIZE);

--- a/src/sessions/builder.rs
+++ b/src/sessions/builder.rs
@@ -85,7 +85,7 @@ impl<T: Config> SessionBuilder<T> {
     /// - Returns [`InvalidRequest`] if a player with that handle has been added before
     /// - Returns [`InvalidRequest`] if the handle is invalid for the given [`PlayerType`]
     ///
-    /// [`InvalidRequest`]: GGRSError::InvalidRequest
+    /// [`InvalidRequest`]: GgrsError::InvalidRequest
     /// [`num_players`]: Self#structfield.num_players
     pub fn add_player(
         mut self,
@@ -132,7 +132,7 @@ impl<T: Config> SessionBuilder<T> {
     /// # Errors
     /// - Returns [`InvalidRequest`] if the prediction window is 0.
     ///
-    /// [`InvalidRequest`]: GGRSError::InvalidRequest
+    /// [`InvalidRequest`]: GgrsError::InvalidRequest
     pub fn with_max_prediction_window(mut self, window: usize) -> Result<Self, GgrsError> {
         if window == 0 {
             return Err(GgrsError::InvalidRequest {
@@ -187,7 +187,7 @@ impl<T: Config> SessionBuilder<T> {
     /// # Errors
     /// - Returns [`InvalidRequest`] if the fps is 0
     ///
-    /// [`InvalidRequest`]: GGRSError::InvalidRequest
+    /// [`InvalidRequest`]: GgrsError::InvalidRequest
     pub fn with_fps(mut self, fps: usize) -> Result<Self, GgrsError> {
         if fps == 0 {
             return Err(GgrsError::InvalidRequest {
@@ -247,7 +247,7 @@ impl<T: Config> SessionBuilder<T> {
     /// # Errors
     /// - Returns [`InvalidRequest`] if insufficient players have been registered.
     ///
-    /// [`InvalidRequest`]: GGRSError::InvalidRequest
+    /// [`InvalidRequest`]: GgrsError::InvalidRequest
     pub fn start_p2p_session(
         mut self,
         socket: impl NonBlockingSocket<T::Address> + 'static,

--- a/src/sessions/p2p_session.rs
+++ b/src/sessions/p2p_session.rs
@@ -6,7 +6,7 @@ use crate::network::protocol::{UdpProtocol, MAX_CHECKSUM_HISTORY_SIZE};
 use crate::sync_layer::SyncLayer;
 use crate::DesyncDetection;
 use crate::{
-    network::protocol::Event, Config, Frame, GgrsEvent, GGRSRequest, NonBlockingSocket,
+    network::protocol::Event, Config, Frame, GgrsEvent, GgrsRequest, NonBlockingSocket,
     PlayerHandle, PlayerType, SessionState, NULL_FRAME,
 };
 
@@ -253,7 +253,7 @@ impl<T: Config> P2PSession<T> {
     /// [`Vec<GGRSRequest>`]: GGRSRequest
     /// [`InvalidRequest`]: GGRSError::InvalidRequest
     /// [`NotSynchronized`]: GGRSError::NotSynchronized
-    pub fn advance_frame(&mut self) -> Result<Vec<GGRSRequest<T>>, GgrsError> {
+    pub fn advance_frame(&mut self) -> Result<Vec<GgrsRequest<T>>, GgrsError> {
         // receive info from remote players, trigger events and send messages
         self.poll_remote_clients();
 
@@ -368,7 +368,7 @@ impl<T: Config> P2PSession<T> {
             .synchronized_inputs(&self.local_connect_status);
         // advance the frame count
         self.sync_layer.advance_frame();
-        requests.push(GGRSRequest::AdvanceFrame { inputs });
+        requests.push(GgrsRequest::AdvanceFrame { inputs });
 
         Ok(requests)
     }
@@ -625,7 +625,7 @@ impl<T: Config> P2PSession<T> {
         &mut self,
         first_incorrect: Frame,
         min_confirmed: Frame,
-        requests: &mut Vec<GGRSRequest<T>>,
+        requests: &mut Vec<GgrsRequest<T>>,
     ) {
         let current_frame = self.sync_layer.current_frame();
         // determine the frame to load
@@ -669,7 +669,7 @@ impl<T: Config> P2PSession<T> {
 
             // advance the frame
             self.sync_layer.advance_frame();
-            requests.push(GGRSRequest::AdvanceFrame { inputs });
+            requests.push(GgrsRequest::AdvanceFrame { inputs });
         }
         // after all this, we should have arrived at the same frame where we started
         assert_eq!(self.sync_layer.current_frame(), current_frame);
@@ -782,7 +782,7 @@ impl<T: Config> P2PSession<T> {
         &mut self,
         last_saved: Frame,
         confirmed_frame: Frame,
-        requests: &mut Vec<GGRSRequest<T>>,
+        requests: &mut Vec<GgrsRequest<T>>,
     ) {
         // in sparse saving mode, we need to make sure not to lose the last saved frame
         if self.sync_layer.current_frame() - last_saved >= self.max_prediction as i32 {

--- a/src/sessions/p2p_session.rs
+++ b/src/sessions/p2p_session.rs
@@ -141,7 +141,7 @@ where
 
     /// notes which inputs have already been sent to the spectators
     next_spectator_frame: Frame,
-    /// The soonest frame on which the session can send a [`GGRSEvent::WaitRecommendation`] again.
+    /// The soonest frame on which the session can send a [`GgrsEvent::WaitRecommendation`] again.
     next_recommended_sleep: Frame,
     /// How many frames we estimate we are ahead of every remote client
     frames_ahead: i32,
@@ -220,7 +220,7 @@ impl<T: Config> P2PSession<T> {
     /// - Returns [`InvalidRequest`] when the given handle does not refer to a local player.
     ///
     /// [`advance_frame()`]: Self#method.advance_frame
-    /// [`InvalidRequest`]: GGRSError::InvalidRequest
+    /// [`InvalidRequest`]: GgrsError::InvalidRequest
     pub fn add_local_input(
         &mut self,
         player_handle: PlayerHandle,
@@ -243,16 +243,16 @@ impl<T: Config> P2PSession<T> {
     }
 
     /// You should call this to notify GGRS that you are ready to advance your gamestate by a single frame.
-    /// Returns an order-sensitive [`Vec<GGRSRequest>`]. You should fulfill all requests in the exact order they are provided.
+    /// Returns an order-sensitive [`Vec<GgrsRequest>`]. You should fulfill all requests in the exact order they are provided.
     /// Failure to do so will cause panics later.
     ///
     /// # Errors
     /// - Returns [`InvalidRequest`] if the provided player handle refers to a remote player.
     /// - Returns [`NotSynchronized`] if the session is not yet ready to accept input. In this case, you either need to start the session or wait for synchronization between clients.
     ///
-    /// [`Vec<GGRSRequest>`]: GGRSRequest
-    /// [`InvalidRequest`]: GGRSError::InvalidRequest
-    /// [`NotSynchronized`]: GGRSError::NotSynchronized
+    /// [`Vec<GgrsRequest>`]: GgrsRequest
+    /// [`InvalidRequest`]: GgrsError::InvalidRequest
+    /// [`NotSynchronized`]: GgrsError::NotSynchronized
     pub fn advance_frame(&mut self) -> Result<Vec<GgrsRequest<T>>, GgrsError> {
         // receive info from remote players, trigger events and send messages
         self.poll_remote_clients();
@@ -429,7 +429,7 @@ impl<T: Config> P2PSession<T> {
     /// # Errors
     /// - Returns [`InvalidRequest`] if you try to disconnect a local player or the provided handle is invalid.
     ///
-    /// [`InvalidRequest`]: GGRSError::InvalidRequest
+    /// [`InvalidRequest`]: GgrsError::InvalidRequest
     pub fn disconnect_player(&mut self, player_handle: PlayerHandle) -> Result<(), GgrsError> {
         match self.player_reg.handles.get(&player_handle) {
             // the local player cannot be disconnected
@@ -463,8 +463,8 @@ impl<T: Config> P2PSession<T> {
     /// - Returns [`InvalidRequest`] if the handle not referring to a remote player or spectator.
     /// - Returns [`NotSynchronized`] if the session is not connected to other clients yet.
     ///
-    /// [`InvalidRequest`]: GGRSError::InvalidRequest
-    /// [`NotSynchronized`]: GGRSError::NotSynchronized
+    /// [`InvalidRequest`]: GgrsError::InvalidRequest
+    /// [`NotSynchronized`]: GgrsError::NotSynchronized
     pub fn network_stats(&self, player_handle: PlayerHandle) -> Result<NetworkStats, GgrsError> {
         match self.player_reg.handles.get(&player_handle) {
             Some(PlayerType::Remote(addr)) => self

--- a/src/sessions/p2p_session.rs
+++ b/src/sessions/p2p_session.rs
@@ -1,4 +1,4 @@
-use crate::error::GGRSError;
+use crate::error::GgrsError;
 use crate::frame_info::PlayerInput;
 use crate::network::messages::ConnectionStatus;
 use crate::network::network_stats::NetworkStats;
@@ -225,14 +225,14 @@ impl<T: Config> P2PSession<T> {
         &mut self,
         player_handle: PlayerHandle,
         input: T::Input,
-    ) -> Result<(), GGRSError> {
+    ) -> Result<(), GgrsError> {
         // make sure the input is for a registered local player
         if !self
             .player_reg
             .local_player_handles()
             .contains(&player_handle)
         {
-            return Err(GGRSError::InvalidRequest {
+            return Err(GgrsError::InvalidRequest {
                 info: "The player handle you provided is not referring to a local player."
                     .to_owned(),
             });
@@ -253,13 +253,13 @@ impl<T: Config> P2PSession<T> {
     /// [`Vec<GGRSRequest>`]: GGRSRequest
     /// [`InvalidRequest`]: GGRSError::InvalidRequest
     /// [`NotSynchronized`]: GGRSError::NotSynchronized
-    pub fn advance_frame(&mut self) -> Result<Vec<GGRSRequest<T>>, GGRSError> {
+    pub fn advance_frame(&mut self) -> Result<Vec<GGRSRequest<T>>, GgrsError> {
         // receive info from remote players, trigger events and send messages
         self.poll_remote_clients();
 
         // session is not running and synchronized
         if self.state != SessionState::Running {
-            return Err(GGRSError::NotSynchronized);
+            return Err(GgrsError::NotSynchronized);
         }
 
         // This list of requests will be returned to the user
@@ -341,7 +341,7 @@ impl<T: Config> P2PSession<T> {
                     self.local_connect_status[handle].last_frame = actual_frame;
                 }
                 None => {
-                    return Err(GGRSError::InvalidRequest {
+                    return Err(GgrsError::InvalidRequest {
                         info: "Missing local input while calling advance_frame().".to_owned(),
                     });
                 }
@@ -430,13 +430,13 @@ impl<T: Config> P2PSession<T> {
     /// - Returns [`InvalidRequest`] if you try to disconnect a local player or the provided handle is invalid.
     ///
     /// [`InvalidRequest`]: GGRSError::InvalidRequest
-    pub fn disconnect_player(&mut self, player_handle: PlayerHandle) -> Result<(), GGRSError> {
+    pub fn disconnect_player(&mut self, player_handle: PlayerHandle) -> Result<(), GgrsError> {
         match self.player_reg.handles.get(&player_handle) {
             // the local player cannot be disconnected
-            None => Err(GGRSError::InvalidRequest {
+            None => Err(GgrsError::InvalidRequest {
                 info: "Invalid Player Handle.".to_owned(),
             }),
-            Some(PlayerType::Local) => Err(GGRSError::InvalidRequest {
+            Some(PlayerType::Local) => Err(GgrsError::InvalidRequest {
                 info: "Local Player cannot be disconnected.".to_owned(),
             }),
             // a remote player can only be disconnected if not already disconnected, since there is some additional logic attached
@@ -446,7 +446,7 @@ impl<T: Config> P2PSession<T> {
                     self.disconnect_player_at_frame(player_handle, last_frame);
                     return Ok(());
                 }
-                Err(GGRSError::InvalidRequest {
+                Err(GgrsError::InvalidRequest {
                     info: "Player already disconnected.".to_owned(),
                 })
             }
@@ -465,7 +465,7 @@ impl<T: Config> P2PSession<T> {
     ///
     /// [`InvalidRequest`]: GGRSError::InvalidRequest
     /// [`NotSynchronized`]: GGRSError::NotSynchronized
-    pub fn network_stats(&self, player_handle: PlayerHandle) -> Result<NetworkStats, GGRSError> {
+    pub fn network_stats(&self, player_handle: PlayerHandle) -> Result<NetworkStats, GgrsError> {
         match self.player_reg.handles.get(&player_handle) {
             Some(PlayerType::Remote(addr)) => self
                 .player_reg
@@ -479,7 +479,7 @@ impl<T: Config> P2PSession<T> {
                 .get(addr)
                 .expect("Endpoint should exist for any registered player")
                 .network_stats(),
-            _ => Err(GGRSError::InvalidRequest {
+            _ => Err(GgrsError::InvalidRequest {
                 info: "Given player handle not referring to a remote player or spectator"
                     .to_owned(),
             }),

--- a/src/sessions/p2p_spectator_session.rs
+++ b/src/sessions/p2p_spectator_session.rs
@@ -7,7 +7,7 @@ use crate::{
         protocol::{Event, UdpProtocol},
     },
     sessions::builder::MAX_EVENT_QUEUE_SIZE,
-    Config, Frame, GgrsError, GGRSEvent, GGRSRequest, InputStatus, NetworkStats, NonBlockingSocket,
+    Config, Frame, GgrsError, GgrsEvent, GGRSRequest, InputStatus, NetworkStats, NonBlockingSocket,
     SessionState, NULL_FRAME,
 };
 
@@ -29,7 +29,7 @@ where
     host_connect_status: Vec<ConnectionStatus>,
     socket: Box<dyn NonBlockingSocket<T::Address>>,
     host: UdpProtocol<T>,
-    event_queue: VecDeque<GGRSEvent<T>>,
+    event_queue: VecDeque<GgrsEvent<T>>,
     current_frame: Frame,
     last_recv_frame: Frame,
     max_frames_behind: usize,
@@ -93,7 +93,7 @@ impl<T: Config> SpectatorSession<T> {
     }
 
     /// Returns all events that happened since last queried for events. If the number of stored events exceeds `MAX_EVENT_QUEUE_SIZE`, the oldest events will be discarded.
-    pub fn events(&mut self) -> Drain<GGRSEvent<T>> {
+    pub fn events(&mut self) -> Drain<GgrsEvent<T>> {
         self.event_queue.drain(..)
     }
 
@@ -206,11 +206,11 @@ impl<T: Config> SpectatorSession<T> {
             // forward to user
             Event::Synchronizing { total, count } => {
                 self.event_queue
-                    .push_back(GGRSEvent::Synchronizing { addr, total, count });
+                    .push_back(GgrsEvent::Synchronizing { addr, total, count });
             }
             // forward to user
             Event::NetworkInterrupted { disconnect_timeout } => {
-                self.event_queue.push_back(GGRSEvent::NetworkInterrupted {
+                self.event_queue.push_back(GgrsEvent::NetworkInterrupted {
                     addr,
                     disconnect_timeout,
                 });
@@ -218,16 +218,16 @@ impl<T: Config> SpectatorSession<T> {
             // forward to user
             Event::NetworkResumed => {
                 self.event_queue
-                    .push_back(GGRSEvent::NetworkResumed { addr });
+                    .push_back(GgrsEvent::NetworkResumed { addr });
             }
             // synced with the host, then forward to user
             Event::Synchronized => {
                 self.state = SessionState::Running;
-                self.event_queue.push_back(GGRSEvent::Synchronized { addr });
+                self.event_queue.push_back(GgrsEvent::Synchronized { addr });
             }
             // disconnect the player, then forward to user
             Event::Disconnected => {
-                self.event_queue.push_back(GGRSEvent::Disconnected { addr });
+                self.event_queue.push_back(GgrsEvent::Disconnected { addr });
             }
             // add the input and all associated information
             Event::Input { input, player } => {

--- a/src/sessions/p2p_spectator_session.rs
+++ b/src/sessions/p2p_spectator_session.rs
@@ -7,7 +7,7 @@ use crate::{
         protocol::{Event, UdpProtocol},
     },
     sessions::builder::MAX_EVENT_QUEUE_SIZE,
-    Config, Frame, GgrsError, GgrsEvent, GGRSRequest, InputStatus, NetworkStats, NonBlockingSocket,
+    Config, Frame, GgrsError, GgrsEvent, GgrsRequest, InputStatus, NetworkStats, NonBlockingSocket,
     SessionState, NULL_FRAME,
 };
 
@@ -106,7 +106,7 @@ impl<T: Config> SpectatorSession<T> {
     ///
     /// [`Vec<GGRSRequest>`]: GGRSRequest
     /// [`NotSynchronized`]: GGRSError::NotSynchronized
-    pub fn advance_frame(&mut self) -> Result<Vec<GGRSRequest<T>>, GgrsError> {
+    pub fn advance_frame(&mut self) -> Result<Vec<GgrsRequest<T>>, GgrsError> {
         // receive info from host, trigger events and send messages
         self.poll_remote_clients();
 
@@ -127,7 +127,7 @@ impl<T: Config> SpectatorSession<T> {
             let frame_to_grab = self.current_frame + 1;
             let synced_inputs = self.inputs_at_frame(frame_to_grab)?;
 
-            requests.push(GGRSRequest::AdvanceFrame {
+            requests.push(GgrsRequest::AdvanceFrame {
                 inputs: synced_inputs,
             });
 

--- a/src/sessions/p2p_spectator_session.rs
+++ b/src/sessions/p2p_spectator_session.rs
@@ -87,7 +87,7 @@ impl<T: Config> SpectatorSession<T> {
     /// # Errors
     /// - Returns [`NotSynchronized`] if the session is not connected to other clients yet.
     ///
-    /// [`NotSynchronized`]: GGRSError::NotSynchronized
+    /// [`NotSynchronized`]: GgrsError::NotSynchronized
     pub fn network_stats(&self) -> Result<NetworkStats, GgrsError> {
         self.host.network_stats()
     }
@@ -98,14 +98,14 @@ impl<T: Config> SpectatorSession<T> {
     }
 
     /// You should call this to notify GGRS that you are ready to advance your gamestate by a single frame.
-    /// Returns an order-sensitive [`Vec<GGRSRequest>`]. You should fulfill all requests in the exact order they are provided.
+    /// Returns an order-sensitive [`Vec<GgrsRequest>`]. You should fulfill all requests in the exact order they are provided.
     /// Failure to do so will cause panics later.
     /// # Errors
     /// - Returns [`NotSynchronized`] if the session is not yet ready to accept input.
     /// In this case, you either need to start the session or wait for synchronization between clients.
     ///
-    /// [`Vec<GGRSRequest>`]: GGRSRequest
-    /// [`NotSynchronized`]: GGRSError::NotSynchronized
+    /// [`Vec<GgrsRequest>`]: GgrsRequest
+    /// [`NotSynchronized`]: GgrsError::NotSynchronized
     pub fn advance_frame(&mut self) -> Result<Vec<GgrsRequest<T>>, GgrsError> {
         // receive info from host, trigger events and send messages
         self.poll_remote_clients();

--- a/src/sessions/sync_test_session.rs
+++ b/src/sessions/sync_test_session.rs
@@ -57,7 +57,7 @@ impl<T: Config> SyncTestSession<T> {
     /// - Returns [`InvalidRequest`] when the given handle is not valid (i.e. not between 0 and num_players).
     ///
     /// [`advance_frame()`]: Self#method.advance_frame
-    /// [`InvalidRequest`]: GGRSError::InvalidRequest
+    /// [`InvalidRequest`]: GgrsError::InvalidRequest
     pub fn add_local_input(
         &mut self,
         player_handle: PlayerHandle,
@@ -74,14 +74,14 @@ impl<T: Config> SyncTestSession<T> {
     }
 
     /// In a sync test, this will advance the state by a single frame and afterwards rollback `check_distance` amount of frames,
-    /// resimulate and compare checksums with the original states. Returns an order-sensitive [`Vec<GGRSRequest>`].
+    /// resimulate and compare checksums with the original states. Returns an order-sensitive [`Vec<GgrsRequest>`].
     /// You should fulfill all requests in the exact order they are provided. Failure to do so will cause panics later.
     ///
     /// # Errors
     /// - Returns [`MismatchedChecksum`] if checksums don't match after resimulation.
     ///
-    /// [`Vec<GGRSRequest>`]: GGRSRequest
-    /// [`MismatchedChecksum`]: GGRSError::MismatchedChecksum
+    /// [`Vec<GgrsRequest>`]: GgrsRequest
+    /// [`MismatchedChecksum`]: GgrsError::MismatchedChecksum
     pub fn advance_frame(&mut self) -> Result<Vec<GgrsRequest<T>>, GgrsError> {
         let mut requests = Vec::new();
 

--- a/src/sessions/sync_test_session.rs
+++ b/src/sessions/sync_test_session.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 
-use crate::error::GGRSError;
+use crate::error::GgrsError;
 use crate::frame_info::PlayerInput;
 use crate::network::messages::ConnectionStatus;
 use crate::sync_layer::SyncLayer;
@@ -62,9 +62,9 @@ impl<T: Config> SyncTestSession<T> {
         &mut self,
         player_handle: PlayerHandle,
         input: T::Input,
-    ) -> Result<(), GGRSError> {
+    ) -> Result<(), GgrsError> {
         if player_handle >= self.num_players {
-            return Err(GGRSError::InvalidRequest {
+            return Err(GgrsError::InvalidRequest {
                 info: "The player handle you provided is not valid.".to_owned(),
             });
         }
@@ -82,7 +82,7 @@ impl<T: Config> SyncTestSession<T> {
     ///
     /// [`Vec<GGRSRequest>`]: GGRSRequest
     /// [`MismatchedChecksum`]: GGRSError::MismatchedChecksum
-    pub fn advance_frame(&mut self) -> Result<Vec<GGRSRequest<T>>, GGRSError> {
+    pub fn advance_frame(&mut self) -> Result<Vec<GGRSRequest<T>>, GgrsError> {
         let mut requests = Vec::new();
 
         // if we advanced far enough into the game do comparisons and rollbacks
@@ -91,7 +91,7 @@ impl<T: Config> SyncTestSession<T> {
             for i in 0..=self.check_distance as i32 {
                 let frame_to_check = self.sync_layer.current_frame() - i;
                 if !self.checksums_consistent(frame_to_check) {
-                    return Err(GGRSError::MismatchedChecksum {
+                    return Err(GgrsError::MismatchedChecksum {
                         frame: frame_to_check,
                     });
                 }
@@ -104,7 +104,7 @@ impl<T: Config> SyncTestSession<T> {
 
         // we require inputs for all players
         if self.num_players != self.local_inputs.len() {
-            return Err(GGRSError::InvalidRequest {
+            return Err(GgrsError::InvalidRequest {
                 info: "Missing local input while calling advance_frame().".to_owned(),
             });
         }

--- a/src/sessions/sync_test_session.rs
+++ b/src/sessions/sync_test_session.rs
@@ -4,7 +4,7 @@ use crate::error::GgrsError;
 use crate::frame_info::PlayerInput;
 use crate::network::messages::ConnectionStatus;
 use crate::sync_layer::SyncLayer;
-use crate::{Config, Frame, GGRSRequest, PlayerHandle};
+use crate::{Config, Frame, GgrsRequest, PlayerHandle};
 
 /// During a [`SyncTestSession`], GGRS will simulate a rollback every frame and resimulate the last n states, where n is the given check distance.
 /// The resimulated checksums will be compared with the original checksums and report if there was a mismatch.
@@ -82,7 +82,7 @@ impl<T: Config> SyncTestSession<T> {
     ///
     /// [`Vec<GGRSRequest>`]: GGRSRequest
     /// [`MismatchedChecksum`]: GGRSError::MismatchedChecksum
-    pub fn advance_frame(&mut self) -> Result<Vec<GGRSRequest<T>>, GgrsError> {
+    pub fn advance_frame(&mut self) -> Result<Vec<GgrsRequest<T>>, GgrsError> {
         let mut requests = Vec::new();
 
         // if we advanced far enough into the game do comparisons and rollbacks
@@ -128,7 +128,7 @@ impl<T: Config> SyncTestSession<T> {
             .synchronized_inputs(&self.dummy_connect_status);
 
         // advance the frame
-        requests.push(GGRSRequest::AdvanceFrame { inputs });
+        requests.push(GgrsRequest::AdvanceFrame { inputs });
         self.sync_layer.advance_frame();
 
         // since this is a sync test, we "cheat" by setting the last confirmed state to the (current state - check_distance), so the sync layer won't complain about missing
@@ -180,7 +180,7 @@ impl<T: Config> SyncTestSession<T> {
         }
     }
 
-    fn adjust_gamestate(&mut self, frame_to: Frame, requests: &mut Vec<GGRSRequest<T>>) {
+    fn adjust_gamestate(&mut self, frame_to: Frame, requests: &mut Vec<GgrsRequest<T>>) {
         let start_frame = self.sync_layer.current_frame();
         let count = start_frame - frame_to;
 
@@ -202,7 +202,7 @@ impl<T: Config> SyncTestSession<T> {
             // then advance
             self.sync_layer.advance_frame();
 
-            requests.push(GGRSRequest::AdvanceFrame { inputs });
+            requests.push(GgrsRequest::AdvanceFrame { inputs });
         }
         assert_eq!(self.sync_layer.current_frame(), start_frame);
     }

--- a/src/sync_layer.rs
+++ b/src/sync_layer.rs
@@ -6,7 +6,7 @@ use crate::error::GgrsError;
 use crate::frame_info::{GameState, PlayerInput};
 use crate::input_queue::InputQueue;
 use crate::network::messages::ConnectionStatus;
-use crate::{Config, Frame, GGRSRequest, InputStatus, PlayerHandle, NULL_FRAME};
+use crate::{Config, Frame, GgrsRequest, InputStatus, PlayerHandle, NULL_FRAME};
 
 /// An [`Arc<Mutex>`] that you can [`save()`]/[`load()`] a `T` to/from. These will be handed to the user as part of a [`GGRSRequest`].
 ///
@@ -125,10 +125,10 @@ impl<T: Config> SyncLayer<T> {
         self.current_frame += 1;
     }
 
-    pub(crate) fn save_current_state(&mut self) -> GGRSRequest<T> {
+    pub(crate) fn save_current_state(&mut self) -> GgrsRequest<T> {
         self.last_saved_frame = self.current_frame;
         let cell = self.saved_states.get_cell(self.current_frame);
-        GGRSRequest::SaveGameState {
+        GgrsRequest::SaveGameState {
             cell,
             frame: self.current_frame,
         }
@@ -146,7 +146,7 @@ impl<T: Config> SyncLayer<T> {
     }
 
     /// Loads the gamestate indicated by `frame_to_load`.
-    pub(crate) fn load_frame(&mut self, frame_to_load: Frame) -> GGRSRequest<T> {
+    pub(crate) fn load_frame(&mut self, frame_to_load: Frame) -> GgrsRequest<T> {
         // The state should not be the current state or the state should not be in the future or too far away in the past
         assert!(
             frame_to_load != NULL_FRAME
@@ -158,7 +158,7 @@ impl<T: Config> SyncLayer<T> {
         assert_eq!(cell.0.lock().frame, frame_to_load);
         self.current_frame = frame_to_load;
 
-        GGRSRequest::LoadGameState {
+        GgrsRequest::LoadGameState {
             cell,
             frame: frame_to_load,
         }

--- a/src/sync_layer.rs
+++ b/src/sync_layer.rs
@@ -8,7 +8,7 @@ use crate::input_queue::InputQueue;
 use crate::network::messages::ConnectionStatus;
 use crate::{Config, Frame, GgrsRequest, InputStatus, PlayerHandle, NULL_FRAME};
 
-/// An [`Arc<Mutex>`] that you can [`save()`]/[`load()`] a `T` to/from. These will be handed to the user as part of a [`GGRSRequest`].
+/// An [`Arc<Mutex>`] that you can [`save()`]/[`load()`] a `T` to/from. These will be handed to the user as part of a [`GgrsRequest`].
 ///
 /// [`save()`]: GameStateCell#method.save
 /// [`load()`]: GameStateCell#method.load

--- a/src/sync_layer.rs
+++ b/src/sync_layer.rs
@@ -2,7 +2,7 @@ use bytemuck::Zeroable;
 use parking_lot::Mutex;
 use std::sync::Arc;
 
-use crate::error::GGRSError;
+use crate::error::GgrsError;
 use crate::frame_info::{GameState, PlayerInput};
 use crate::input_queue::InputQueue;
 use crate::network::messages::ConnectionStatus;
@@ -170,12 +170,12 @@ impl<T: Config> SyncLayer<T> {
         &mut self,
         player_handle: PlayerHandle,
         input: PlayerInput<T::Input>,
-    ) -> Result<Frame, GGRSError> {
+    ) -> Result<Frame, GgrsError> {
         let frames_ahead = self.current_frame - self.last_confirmed_frame;
         if self.current_frame >= self.max_prediction as i32
             && frames_ahead >= self.max_prediction as i32
         {
-            return Err(GGRSError::PredictionThreshold);
+            return Err(GgrsError::PredictionThreshold);
         }
 
         // The input provided should match the current frame, we account for input delay later

--- a/tests/stubs.rs
+++ b/tests/stubs.rs
@@ -3,7 +3,7 @@ use std::collections::hash_map::DefaultHasher;
 use std::hash::{Hash, Hasher};
 use std::net::SocketAddr;
 
-use ggrs::{Config, Frame, GgrsRequest, GameStateCell, InputStatus};
+use ggrs::{Config, Frame, GameStateCell, GgrsRequest, InputStatus};
 
 fn calculate_hash<T: Hash>(t: &T) -> u64 {
     let mut s = DefaultHasher::new();

--- a/tests/stubs.rs
+++ b/tests/stubs.rs
@@ -3,7 +3,7 @@ use std::collections::hash_map::DefaultHasher;
 use std::hash::{Hash, Hasher};
 use std::net::SocketAddr;
 
-use ggrs::{Config, Frame, GGRSRequest, GameStateCell, InputStatus};
+use ggrs::{Config, Frame, GgrsRequest, GameStateCell, InputStatus};
 
 fn calculate_hash<T: Hash>(t: &T) -> u64 {
     let mut s = DefaultHasher::new();
@@ -39,12 +39,12 @@ impl GameStub {
     }
 
     #[allow(dead_code)]
-    pub fn handle_requests(&mut self, requests: Vec<GGRSRequest<StubConfig>>) {
+    pub fn handle_requests(&mut self, requests: Vec<GgrsRequest<StubConfig>>) {
         for request in requests {
             match request {
-                GGRSRequest::LoadGameState { cell, .. } => self.load_game_state(cell),
-                GGRSRequest::SaveGameState { cell, frame } => self.save_game_state(cell, frame),
-                GGRSRequest::AdvanceFrame { inputs } => self.advance_frame(inputs),
+                GgrsRequest::LoadGameState { cell, .. } => self.load_game_state(cell),
+                GgrsRequest::SaveGameState { cell, frame } => self.save_game_state(cell, frame),
+                GgrsRequest::AdvanceFrame { inputs } => self.advance_frame(inputs),
             }
         }
     }
@@ -79,12 +79,12 @@ impl RandomChecksumGameStub {
     }
 
     #[allow(dead_code)]
-    pub fn handle_requests(&mut self, requests: Vec<GGRSRequest<StubConfig>>) {
+    pub fn handle_requests(&mut self, requests: Vec<GgrsRequest<StubConfig>>) {
         for request in requests {
             match request {
-                GGRSRequest::LoadGameState { cell, .. } => self.load_game_state(cell),
-                GGRSRequest::SaveGameState { cell, frame } => self.save_game_state(cell, frame),
-                GGRSRequest::AdvanceFrame { inputs } => self.advance_frame(inputs),
+                GgrsRequest::LoadGameState { cell, .. } => self.load_game_state(cell),
+                GgrsRequest::SaveGameState { cell, frame } => self.save_game_state(cell, frame),
+                GgrsRequest::AdvanceFrame { inputs } => self.advance_frame(inputs),
             }
         }
     }

--- a/tests/stubs_enum.rs
+++ b/tests/stubs_enum.rs
@@ -2,7 +2,7 @@ use std::collections::hash_map::DefaultHasher;
 use std::hash::{Hash, Hasher};
 use std::net::SocketAddr;
 
-use ggrs::{Config, Frame, GgrsRequest, GameStateCell, InputStatus};
+use ggrs::{Config, Frame, GameStateCell, GgrsRequest, InputStatus};
 
 fn calculate_hash<T: Hash>(t: &T) -> u64 {
     let mut s = DefaultHasher::new();

--- a/tests/stubs_enum.rs
+++ b/tests/stubs_enum.rs
@@ -2,7 +2,7 @@ use std::collections::hash_map::DefaultHasher;
 use std::hash::{Hash, Hasher};
 use std::net::SocketAddr;
 
-use ggrs::{Config, Frame, GGRSRequest, GameStateCell, InputStatus};
+use ggrs::{Config, Frame, GgrsRequest, GameStateCell, InputStatus};
 
 fn calculate_hash<T: Hash>(t: &T) -> u64 {
     let mut s = DefaultHasher::new();
@@ -45,12 +45,12 @@ impl GameStubEnum {
     }
 
     #[allow(dead_code)]
-    pub fn handle_requests(&mut self, requests: Vec<GGRSRequest<StubEnumConfig>>) {
+    pub fn handle_requests(&mut self, requests: Vec<GgrsRequest<StubEnumConfig>>) {
         for request in requests {
             match request {
-                GGRSRequest::LoadGameState { cell, .. } => self.load_game_state(cell),
-                GGRSRequest::SaveGameState { cell, frame } => self.save_game_state(cell, frame),
-                GGRSRequest::AdvanceFrame { inputs } => self.advance_frame(inputs),
+                GgrsRequest::LoadGameState { cell, .. } => self.load_game_state(cell),
+                GgrsRequest::SaveGameState { cell, frame } => self.save_game_state(cell, frame),
+                GgrsRequest::AdvanceFrame { inputs } => self.advance_frame(inputs),
             }
         }
     }

--- a/tests/test_p2p_session.rs
+++ b/tests/test_p2p_session.rs
@@ -1,7 +1,7 @@
 mod stubs;
 
 use ggrs::{
-    DesyncDetection, GgrsError, GGRSEvent, PlayerType, SessionBuilder, SessionState,
+    DesyncDetection, GgrsError, GgrsEvent, PlayerType, SessionBuilder, SessionState,
     UdpNonBlockingSocket,
 };
 use serial_test::serial;
@@ -178,7 +178,7 @@ fn test_desyncs_detected() -> Result<(), GgrsError> {
 
     // drain events
     assert!(sess1.events().chain(sess2.events()).all(|e| match e {
-        GGRSEvent::Synchronizing { .. } | GGRSEvent::Synchronized { .. } => true,
+        GgrsEvent::Synchronizing { .. } | GgrsEvent::Synchronized { .. } => true,
         _ => false,
     }));
 
@@ -229,7 +229,7 @@ fn test_desyncs_detected() -> Result<(), GgrsError> {
     assert_eq!(sess1_events.len(), 1);
     assert_eq!(sess2_events.len(), 1);
 
-    let GGRSEvent::DesyncDetected {
+    let GgrsEvent::DesyncDetected {
         frame: desync_frame1,
         local_checksum: desync_local_checksum1,
         remote_checksum: desync_remote_checksum1,
@@ -242,7 +242,7 @@ fn test_desyncs_detected() -> Result<(), GgrsError> {
     assert_eq!(desync_addr1, addr2);
     assert_ne!(desync_local_checksum1, desync_remote_checksum1);
 
-    let GGRSEvent::DesyncDetected {
+    let GgrsEvent::DesyncDetected {
         frame: desync_frame2,
         local_checksum: desync_local_checksum2,
         remote_checksum: desync_remote_checksum2,
@@ -294,7 +294,7 @@ fn test_desyncs_and_input_delay_no_panic() -> Result<(), GgrsError> {
 
     // drain events
     assert!(sess1.events().chain(sess2.events()).all(|e| match e {
-        GGRSEvent::Synchronizing { .. } | GGRSEvent::Synchronized { .. } => true,
+        GgrsEvent::Synchronizing { .. } | GgrsEvent::Synchronized { .. } => true,
         _ => false,
     }));
 

--- a/tests/test_p2p_session.rs
+++ b/tests/test_p2p_session.rs
@@ -1,7 +1,7 @@
 mod stubs;
 
 use ggrs::{
-    DesyncDetection, GGRSError, GGRSEvent, PlayerType, SessionBuilder, SessionState,
+    DesyncDetection, GgrsError, GGRSEvent, PlayerType, SessionBuilder, SessionState,
     UdpNonBlockingSocket,
 };
 use serial_test::serial;
@@ -10,7 +10,7 @@ use stubs::{StubConfig, StubInput};
 
 #[test]
 #[serial]
-fn test_add_more_players() -> Result<(), GGRSError> {
+fn test_add_more_players() -> Result<(), GgrsError> {
     let socket = UdpNonBlockingSocket::bind_to_port(7777).unwrap();
     let remote_addr1 = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 8080);
     let remote_addr2 = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 8081);
@@ -30,7 +30,7 @@ fn test_add_more_players() -> Result<(), GGRSError> {
 
 #[test]
 #[serial]
-fn test_start_session() -> Result<(), GGRSError> {
+fn test_start_session() -> Result<(), GgrsError> {
     let socket = UdpNonBlockingSocket::bind_to_port(7777).unwrap();
     let remote_addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 8080);
     let spec_addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 8090);
@@ -45,7 +45,7 @@ fn test_start_session() -> Result<(), GGRSError> {
 
 #[test]
 #[serial]
-fn test_disconnect_player() -> Result<(), GGRSError> {
+fn test_disconnect_player() -> Result<(), GgrsError> {
     let socket = UdpNonBlockingSocket::bind_to_port(7777).unwrap();
     let remote_addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 8080);
     let spec_addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 8090);
@@ -67,7 +67,7 @@ fn test_disconnect_player() -> Result<(), GGRSError> {
 
 #[test]
 #[serial]
-fn test_synchronize_p2p_sessions() -> Result<(), GGRSError> {
+fn test_synchronize_p2p_sessions() -> Result<(), GgrsError> {
     let addr1 = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 7777);
     let addr2 = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 8888);
 
@@ -99,7 +99,7 @@ fn test_synchronize_p2p_sessions() -> Result<(), GGRSError> {
 
 #[test]
 #[serial]
-fn test_advance_frame_p2p_sessions() -> Result<(), GGRSError> {
+fn test_advance_frame_p2p_sessions() -> Result<(), GgrsError> {
     let addr1 = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 7777);
     let addr2 = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 8888);
 
@@ -150,7 +150,7 @@ fn test_advance_frame_p2p_sessions() -> Result<(), GGRSError> {
 
 #[test]
 #[serial]
-fn test_desyncs_detected() -> Result<(), GGRSError> {
+fn test_desyncs_detected() -> Result<(), GgrsError> {
     let addr1 = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 7777);
     let addr2 = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 8888);
     let desync_mode = DesyncDetection::On { interval: 100 };
@@ -264,7 +264,7 @@ fn test_desyncs_detected() -> Result<(), GGRSError> {
 
 #[test]
 #[serial]
-fn test_desyncs_and_input_delay_no_panic() -> Result<(), GGRSError> {
+fn test_desyncs_and_input_delay_no_panic() -> Result<(), GgrsError> {
     let addr1 = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 7777);
     let addr2 = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 8888);
     let desync_mode = DesyncDetection::On { interval: 100 };

--- a/tests/test_p2p_spectator_session.rs
+++ b/tests/test_p2p_spectator_session.rs
@@ -1,6 +1,6 @@
 mod stubs;
 
-use ggrs::{GGRSError, PlayerType, SessionBuilder, SessionState, UdpNonBlockingSocket};
+use ggrs::{GgrsError, PlayerType, SessionBuilder, SessionState, UdpNonBlockingSocket};
 use serial_test::serial;
 use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 use stubs::StubConfig;
@@ -16,7 +16,7 @@ fn test_start_session() {
 
 #[test]
 #[serial]
-fn test_synchronize_with_host() -> Result<(), GGRSError> {
+fn test_synchronize_with_host() -> Result<(), GgrsError> {
     let host_addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 7777);
     let spec_addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 8888);
 

--- a/tests/test_synctest_session.rs
+++ b/tests/test_synctest_session.rs
@@ -1,7 +1,7 @@
 mod stubs;
 mod stubs_enum;
 
-use ggrs::{GGRSError, GGRSRequest, SessionBuilder};
+use ggrs::{GgrsError, GGRSRequest, SessionBuilder};
 use stubs::{StubConfig, StubInput};
 
 #[test]
@@ -12,7 +12,7 @@ fn test_create_session() {
 }
 
 #[test]
-fn test_advance_frame_no_rollbacks() -> Result<(), GGRSError> {
+fn test_advance_frame_no_rollbacks() -> Result<(), GgrsError> {
     let check_distance = 0;
     let mut stub = stubs::GameStub::new();
     let mut sess = SessionBuilder::new()
@@ -32,7 +32,7 @@ fn test_advance_frame_no_rollbacks() -> Result<(), GGRSError> {
 }
 
 #[test]
-fn test_advance_frame_with_rollbacks() -> Result<(), GGRSError> {
+fn test_advance_frame_with_rollbacks() -> Result<(), GgrsError> {
     let check_distance = 2;
     let mut stub = stubs::GameStub::new();
     let mut sess = SessionBuilder::new()
@@ -65,7 +65,7 @@ fn test_advance_frame_with_rollbacks() -> Result<(), GGRSError> {
 }
 
 #[test]
-fn test_advance_frames_with_delayed_input() -> Result<(), GGRSError> {
+fn test_advance_frames_with_delayed_input() -> Result<(), GgrsError> {
     let check_distance = 7;
     let mut stub = stubs::GameStub::new();
     let mut sess = SessionBuilder::new()

--- a/tests/test_synctest_session.rs
+++ b/tests/test_synctest_session.rs
@@ -1,7 +1,7 @@
 mod stubs;
 mod stubs_enum;
 
-use ggrs::{GgrsError, GGRSRequest, SessionBuilder};
+use ggrs::{GgrsError, GgrsRequest, SessionBuilder};
 use stubs::{StubConfig, StubInput};
 
 #[test]
@@ -45,16 +45,16 @@ fn test_advance_frame_with_rollbacks() -> Result<(), GgrsError> {
         let requests = sess.advance_frame()?;
         if i <= check_distance {
             assert_eq!(requests.len(), 2); // save, advance
-            assert!(matches!(requests[0], GGRSRequest::SaveGameState { .. }));
-            assert!(matches!(requests[1], GGRSRequest::AdvanceFrame { .. }));
+            assert!(matches!(requests[0], GgrsRequest::SaveGameState { .. }));
+            assert!(matches!(requests[1], GgrsRequest::AdvanceFrame { .. }));
         } else {
             assert_eq!(requests.len(), 6); // load, advance, save, advance, save, advance
-            assert!(matches!(requests[0], GGRSRequest::LoadGameState { .. })); // rollback
-            assert!(matches!(requests[1], GGRSRequest::AdvanceFrame { .. })); // rollback
-            assert!(matches!(requests[2], GGRSRequest::SaveGameState { .. })); // rollback
-            assert!(matches!(requests[3], GGRSRequest::AdvanceFrame { .. })); // rollback
-            assert!(matches!(requests[4], GGRSRequest::SaveGameState { .. }));
-            assert!(matches!(requests[5], GGRSRequest::AdvanceFrame { .. }));
+            assert!(matches!(requests[0], GgrsRequest::LoadGameState { .. })); // rollback
+            assert!(matches!(requests[1], GgrsRequest::AdvanceFrame { .. })); // rollback
+            assert!(matches!(requests[2], GgrsRequest::SaveGameState { .. })); // rollback
+            assert!(matches!(requests[3], GgrsRequest::AdvanceFrame { .. })); // rollback
+            assert!(matches!(requests[4], GgrsRequest::SaveGameState { .. }));
+            assert!(matches!(requests[5], GgrsRequest::AdvanceFrame { .. }));
         }
 
         stub.handle_requests(requests);

--- a/tests/test_synctest_session_enum.rs
+++ b/tests/test_synctest_session_enum.rs
@@ -1,9 +1,9 @@
 mod stubs_enum;
 
-use ggrs::{GGRSError, SessionBuilder};
+use ggrs::{GgrsError, SessionBuilder};
 
 #[test]
-fn test_enum_advance_frames_with_delayed_input() -> Result<(), GGRSError> {
+fn test_enum_advance_frames_with_delayed_input() -> Result<(), GgrsError> {
     let check_distance = 7;
     let mut stub = stubs_enum::GameStubEnum::new();
     let mut sess = SessionBuilder::new()


### PR DESCRIPTION
To prepare for the next release, it's time to introduce breaking changes!

According to the [rust naming conventions](https://rust-lang.github.io/api-guidelines/naming.html#:~:text=In%20UpperCamelCase%2C%20acronyms%20and%20contractions%20of%20compound%20words%20count%20as%20one%20word%3A%20use%20Uuid%20rather%20than%20UUID%2C%20Usize%20rather%20than%20USize%20or%20Stdin%20rather%20than%20StdIn.), Acronyms should not be fully uppercase. We already do this in bevy_ggrs, now it is time to also implement that change here.

- Renamed `GGRSError` to `GgrsError`
- Renamed `GGRSEvent` to `GgrsEvent`
- Renamed `GGRSRequest` to `GgrsRequest`
- Also removed deprecated and unused `GgrsError` variants