### PR TITLE
update parking_lot to 0.12

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ serde = { version = "1.0", features = ["derive"] }
 bincode = "1.3"
 rand = "0.8"
 bitfield-rle = "0.2.1"
-parking_lot = "0.11"
+parking_lot = "0.12"
 instant = "0.1"
 bytemuck = {version = "1.9", features = ["derive"]}
 getrandom = {version = "0.2", optional = true}


### PR DESCRIPTION
Hello 👋 

[Bones](https://github.com/fishfolk/bones), the meta-engine built on Bevy that powers [jumpy](github.com/fishfolk/jumpy), is trying to reduce its dependencies. Currently we have a dependency on versions `0.11` and `0.12` of `parking_lot` and this upgrade would help us slim down.

## Changes

- Update `parking_lot` from `0.11` to `0.12` (see [the changelog](https://github.com/Amanieu/parking_lot/blob/master/CHANGELOG.md#parking_lot-0120-parking_lot_core-090-lock_api-046-2022-01-28))
