### PR TITLE
fix: Fix result error type for bitfield-rle update to 0.2.1

### DIFF
--- a/src/network/compression.rs
+++ b/src/network/compression.rs
@@ -32,7 +32,7 @@ pub(crate) fn delta_encode<'a>(
 pub(crate) fn decode(
     reference: &[u8],
     data: &[u8],
-) -> Result<Vec<Vec<u8>>, Box<dyn std::error::Error>> {
+) -> Result<Vec<Vec<u8>>, Box<dyn std::error::Error + Send + Sync>> {
     // decode the RLE encoding first
     let buf = bitfield_rle::decode(data)?;
 


### PR DESCRIPTION
[bitfield-rle](https://github.com/mafintosh/bitfield-rle) just published version 0.2.1 which removes dependency on failure crate, which was failing advisories for being unmaintained.

GGRS uses bitfield-rle `0.2` (fix version not restricted), when crates depending on ggrs update bitfield-rle in lock file, there is a related compiler error due to bitfield-rle error type changing.

This should fix those issues and allow dependent crates on ggrs to upgrade bitfield-rle successfully.