### PR TITLE
Possible fix for PredictionThreshold error dropping rollback requests causing desync

### DIFF
--- a/src/input_queue.rs
+++ b/src/input_queue.rs
@@ -60,9 +60,12 @@ impl<T: Config> InputQueue<T> {
         self.frame_delay = delay;
     }
 
+    pub(crate) fn reset_first_incorrect_frame(&mut self) {
+        self.first_incorrect_frame = NULL_FRAME;
+    }
+
     pub(crate) fn reset_prediction(&mut self) {
         self.prediction.frame = NULL_FRAME;
-        self.first_incorrect_frame = NULL_FRAME;
         self.last_requested_frame = NULL_FRAME;
     }
 
@@ -104,7 +107,9 @@ impl<T: Config> InputQueue<T> {
     pub(crate) fn input(&mut self, requested_frame: Frame) -> (T::Input, InputStatus) {
         // No one should ever try to grab any input when we have a prediction error.
         // Doing so means that we're just going further down the wrong path. Assert this to verify that it's true.
-        assert!(self.first_incorrect_frame == NULL_FRAME);
+        //
+        // TODO: We no longer reset this until certain rollback will be performed. Figure out what to do with assert?
+        // assert!(self.first_incorrect_frame == NULL_FRAME);
 
         // Remember the last requested frame number for later. We'll need this in add_input() to drop out of prediction mode.
         self.last_requested_frame = requested_frame;

--- a/src/sync_layer.rs
+++ b/src/sync_layer.rs
@@ -139,6 +139,12 @@ impl<T: Config> SyncLayer<T> {
         self.input_queues[player_handle].set_frame_delay(delay);
     }
 
+    pub(crate) fn reset_first_incorrect_frame(&mut self) {
+        for i in 0..self.num_players {
+            self.input_queues[i].reset_first_incorrect_frame();
+        }
+    }
+
     pub(crate) fn reset_prediction(&mut self) {
         for i in 0..self.num_players {
             self.input_queues[i].reset_prediction();

--- a/tests/debug_socket.rs
+++ b/tests/debug_socket.rs
@@ -1,0 +1,103 @@
+use std::{
+    collections::HashMap,
+    hash::Hash,
+    sync::{Arc, Mutex},
+};
+
+pub type MessageBuffer<A> = Vec<(A, ggrs::Message)>;
+
+/// A dummy socket for reproducing controlled delays in delivering messages.
+///
+/// No messages sent will be made available to receiver unless test implementor
+/// explicitly flushes message. This allows implementing tests that wish to reproduce
+/// precise delays in message delivery.
+///
+/// [`DebugSocket::build_sockets`] will generate connected sockets for all addresses.
+#[derive(Default, Clone)]
+pub struct DebugSocket<A: Clone + PartialEq + Eq + Hash> {
+    /// Messages sent, but not yet flushed to be made available to receiver.
+    sent_messages: HashMap<A, Arc<Mutex<Vec<ggrs::Message>>>>,
+
+    /// Message buffers per address that are shared between all sockets.
+    /// When socket flushes messages to recepient, messages moved from sent buffer
+    /// to remote buffer.
+    remote_delivery_buffers: HashMap<A, Arc<Mutex<MessageBuffer<A>>>>,
+
+    /// Delivered messages ready for consumption for local owner of socket
+    received_messages: Arc<Mutex<MessageBuffer<A>>>,
+
+    /// Address of local socket
+    local_addr: A,
+}
+
+impl<A> DebugSocket<A>
+where
+    A: Clone + PartialEq + Eq + Hash,
+{
+    /// Build socket for each address such that each one can write to
+    /// any other address.
+    pub fn build_sockets(addrs: Vec<A>) -> Vec<DebugSocket<A>> {
+        // Create shared buffer for each address
+        let receive_buffers: HashMap<A, Arc<Mutex<MessageBuffer<A>>>> =
+            addrs.iter().fold(Default::default(), |mut map, addr| {
+                map.insert(addr.clone(), Arc::new(Mutex::new(vec![])));
+                map
+            });
+
+        let mut sockets = Vec::<DebugSocket<A>>::default();
+        for addr in addrs.clone() {
+            sockets.push(DebugSocket {
+                sent_messages: addrs.iter().fold(Default::default(), |mut map, addr| {
+                    map.insert(addr.clone(), Arc::new(Mutex::new(vec![])));
+                    map
+                }),
+                remote_delivery_buffers: receive_buffers.clone(),
+                // Receive message from delivery buffer for this address
+                received_messages: receive_buffers.get(&addr).unwrap().clone(),
+                local_addr: addr,
+            })
+        }
+        sockets
+    }
+
+    /// Deliver messages sent to other receiving sockets
+    pub fn flush_message(&mut self) {
+        for (addr, sent) in self.sent_messages.iter_mut() {
+            let mut sent = sent.lock().unwrap();
+            let mut remote_buffer = self
+                .remote_delivery_buffers
+                .get_mut(addr)
+                .unwrap()
+                .lock()
+                .unwrap();
+
+            remote_buffer.extend(sent.drain(..).map(|m| (self.local_addr.clone(), m)));
+        }
+    }
+
+    /// Deliver messages sent to specified address
+    #[allow(dead_code)]
+    pub fn flush_message_for_addr(&mut self, addr: A) {
+        let mut sent = self.sent_messages.get_mut(&addr).unwrap().lock().unwrap();
+        let mut remote_buffer = self
+            .remote_delivery_buffers
+            .get_mut(&addr)
+            .unwrap()
+            .lock()
+            .unwrap();
+
+        remote_buffer.extend(sent.drain(..).map(|m| (self.local_addr.clone(), m)));
+    }
+}
+
+impl<A: Clone + PartialEq + Eq + Hash> ggrs::NonBlockingSocket<A> for DebugSocket<A> {
+    fn send_to(&mut self, msg: &ggrs::Message, addr: &A) {
+        let mut sent = self.sent_messages.get_mut(addr).unwrap().lock().unwrap();
+        sent.push(msg.clone());
+    }
+
+    fn receive_all_messages(&mut self) -> Vec<(A, ggrs::Message)> {
+        let mut messages = self.received_messages.lock().unwrap();
+        messages.drain(..).collect()
+    }
+}


### PR DESCRIPTION
Here are some changes and comments that seem to fix https://github.com/gschup/ggrs/issues/75

This is a draft PR as I am not necessarily suggesting we merge this as is (especially the test - but included for reference to help see what conditions cause this issue. Putting in PR mostly so easier to comment on specific pieces of diff here.

This fixes the test, and also resolves seems to prevent any further desync in Jumpy.

### Overview

The core of the problem is that when adding input at max prediction, we return PredictThreshold error and then requests are not returned and processed by client. By this point, we had already cleared first_incorrect_frame, updated confirmed frame on sync layer, and dropped inputs from before confirmed frame. This is a problem because the pre-confirmed frame inputs sent to be used in correction were not actually processed and are now gone.

Now we speculatively check if client will hit prediction error earlier in advance_frame. At this point, sync_layer.confirmed_frame has not been updated, so we use the 'speculative' confirmed frame local value in advance_frame.

We now only reset first_incorrect_frame and commit speculative confirmed frame to sync layer if and only if we are certain we are not at max prediction window. This means if we do error, in future frames we will still determine we need to rollback due to first_incorrect_frame being preserved, and our inputs / last confirmed frame are still valid.

### Other Notes:
I put a couple TODOs around other spots I expect will cause desync, have not handled all failure cases related to this issue. Will investigate those further later + repro desync for those cases in their own tests to verify. 

I also have not reviewed sync test session or any spectator code, possibly related issues there.