### PR TITLE
Fix/Feature: Lockstep

### DIFF
--- a/examples/ex_game/ex_game_p2p.rs
+++ b/examples/ex_game/ex_game_p2p.rs
@@ -1,7 +1,7 @@
 mod ex_game;
 
 use ex_game::{GGRSConfig, Game};
-use ggrs::{GgrsError, PlayerType, SessionBuilder, SessionState, UdpNonBlockingSocket};
+use ggrs::{PlayerType, SessionBuilder, SessionState, UdpNonBlockingSocket};
 use instant::{Duration, Instant};
 use macroquad::prelude::*;
 use std::net::SocketAddr;
@@ -45,6 +45,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .with_desync_detection_mode(ggrs::DesyncDetection::On { interval: 100 })
         // (optional) set expected update frequency
         .with_fps(FPS as usize)?
+        // secret trick: set the prediction to 0 to fall back to lockstep netcode
+        //.with_max_prediction_window(0)
         // (optional) set input delay for the local player
         .with_input_delay(2);
 
@@ -112,10 +114,6 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
                 match sess.advance_frame() {
                     Ok(requests) => game.handle_requests(requests),
-                    Err(GgrsError::PredictionThreshold) => {
-                        println!("Frame {} skipped", sess.current_frame())
-                    }
-
                     Err(e) => return Err(Box::new(e)),
                 }
             }

--- a/src/network/compression.rs
+++ b/src/network/compression.rs
@@ -64,14 +64,6 @@ pub(crate) fn delta_decode(ref_bytes: &[u8], data: &[u8]) -> Vec<Vec<u8>> {
 mod compression_tests {
     use super::*;
 
-    use bytemuck::{Pod, Zeroable};
-
-    #[repr(C)]
-    #[derive(Copy, Clone, PartialEq, Pod, Zeroable)]
-    struct TestInput {
-        inp: u8,
-    }
-
     #[test]
     fn test_encode_decode() {
         let ref_input = vec![0, 0, 0, 1];

--- a/src/network/protocol.rs
+++ b/src/network/protocol.rs
@@ -490,7 +490,7 @@ impl<T: Config> UdpProtocol<T> {
 
             body.ack_frame = self.last_recv_frame();
             body.disconnect_requested = self.state == ProtocolState::Disconnected;
-            body.peer_connect_status = connect_status.to_owned();
+            connect_status.clone_into(&mut body.peer_connect_status);
 
             self.queue_message(MessageBody::Input(body));
         }

--- a/src/sessions/builder.rs
+++ b/src/sessions/builder.rs
@@ -128,20 +128,9 @@ impl<T: Config> SessionBuilder<T> {
     }
 
     /// Change the maximum prediction window. Default is 8.
-    ///
-    /// # Errors
-    /// - Returns [`InvalidRequest`] if the prediction window is 0.
-    ///
-    /// [`InvalidRequest`]: GgrsError::InvalidRequest
-    pub fn with_max_prediction_window(mut self, window: usize) -> Result<Self, GgrsError> {
-        if window == 0 {
-            return Err(GgrsError::InvalidRequest {
-                info: "Currently, only prediction windows above 0 are supported".to_owned(),
-            });
-        }
-
+    pub fn with_max_prediction_window(mut self, window: usize) -> Self {
         self.max_prediction = window;
-        Ok(self)
+        self
     }
 
     /// Change the amount of frames GGRS will delay the inputs for local players.

--- a/src/sessions/p2p_session.rs
+++ b/src/sessions/p2p_session.rs
@@ -335,10 +335,11 @@ impl<T: Config> P2PSession<T> {
                 Some(player_input) => {
                     // send the input into the sync layer
                     let actual_frame = self.sync_layer.add_local_input(handle, *player_input)?;
-                    assert!(actual_frame != NULL_FRAME);
-                    // if not dropped, send the input to all other clients, but with the correct frame (influenced by input delay)
-                    player_input.frame = actual_frame;
-                    self.local_connect_status[handle].last_frame = actual_frame;
+                    if actual_frame != NULL_FRAME {
+                        // if not dropped, send the input to all other clients, but with the correct frame (influenced by input delay)
+                        player_input.frame = actual_frame;
+                        self.local_connect_status[handle].last_frame = actual_frame;
+                    }
                 }
                 None => {
                     return Err(GgrsError::InvalidRequest {

--- a/src/sessions/p2p_session.rs
+++ b/src/sessions/p2p_session.rs
@@ -341,7 +341,10 @@ impl<T: Config> P2PSession<T> {
         // register local inputs in the system and send them
         for handle in self.player_reg.local_player_handles() {
             // we have checked that these all exist
-            let player_input =  self.local_inputs.get_mut(&handle).expect("Missing local input while calling advance_frame().");
+            let player_input = self
+                .local_inputs
+                .get_mut(&handle)
+                .expect("Missing local input while calling advance_frame().");
             // send the input into the sync layer
             let actual_frame = self.sync_layer.add_local_input(handle, *player_input);
             player_input.frame = actual_frame;
@@ -377,7 +380,10 @@ impl<T: Config> P2PSession<T> {
             self.local_inputs.clear();
             requests.push(GgrsRequest::AdvanceFrame { inputs });
         } else {
-            println!("Prediction Threshold reached. Skipping on frame {}", self.sync_layer.current_frame());
+            println!(
+                "Prediction Threshold reached. Skipping on frame {}",
+                self.sync_layer.current_frame()
+            );
         }
 
         Ok(requests)

--- a/src/sessions/sync_test_session.rs
+++ b/src/sessions/sync_test_session.rs
@@ -115,7 +115,7 @@ impl<T: Config> SyncTestSession<T> {
         // pass all inputs into the sync layer
         for (&handle, &input) in self.local_inputs.iter() {
             // send the input into the sync layer
-            self.sync_layer.add_local_input(handle, input)?;
+            self.sync_layer.add_local_input(handle, input);
         }
         // clear local inputs after using them
         self.local_inputs.clear();

--- a/src/sync_layer.rs
+++ b/src/sync_layer.rs
@@ -68,10 +68,13 @@ pub(crate) struct SavedStates<T: Clone> {
 
 impl<T: Clone> SavedStates<T> {
     fn new(max_pred: usize) -> Self {
-        // the states are two cells bigger than the max prediction frames in order to account for
-        // the next frame needing a space and still being able to rollback the max distance
-        let mut states = Vec::with_capacity(max_pred + 2);
+        let mut states = Vec::with_capacity(max_pred);
         for _ in 0..max_pred {
+            states.push(GameStateCell::default());
+        }
+
+        //TODO: if lockstep, we still provide a single cell for saving. this should be replaced
+        if max_pred == 0 {
             states.push(GameStateCell::default());
         }
 
@@ -79,6 +82,10 @@ impl<T: Clone> SavedStates<T> {
     }
 
     fn get_cell(&self, frame: Frame) -> GameStateCell<T> {
+        //TODO: if lockstep, we still provide a single cell for saving. this should be replaced
+        if self.states.len() == 0 {
+            return self.states[0].clone();
+        }
         assert!(frame >= 0);
         let pos = frame as usize % self.states.len();
         self.states[pos].clone()

--- a/src/sync_layer.rs
+++ b/src/sync_layer.rs
@@ -180,7 +180,7 @@ impl<T: Config> SyncLayer<T> {
     ) -> Result<Frame, GgrsError> {
         let frames_ahead = self.current_frame - self.last_confirmed_frame;
         if self.current_frame >= self.max_prediction as i32
-            && frames_ahead >= self.max_prediction as i32
+            && frames_ahead > self.max_prediction as i32
         {
             return Err(GgrsError::PredictionThreshold);
         }

--- a/src/sync_layer.rs
+++ b/src/sync_layer.rs
@@ -63,6 +63,7 @@ impl<T: Clone> std::fmt::Debug for GameStateCell<T> {
 #[derive(Clone)]
 pub(crate) struct SavedStates<T: Clone> {
     pub states: Vec<GameStateCell<T>>,
+    max_pred: usize,
 }
 
 impl<T: Clone> SavedStates<T> {
@@ -72,17 +73,17 @@ impl<T: Clone> SavedStates<T> {
             states.push(GameStateCell::default());
         }
 
-        //TODO: if lockstep, we still provide a single cell for saving. this should be replaced
+        // if lockstep, we still provide a single cell for saving.
         if max_pred == 0 {
             states.push(GameStateCell::default());
         }
 
-        Self { states }
+        Self { states, max_pred }
     }
 
     fn get_cell(&self, frame: Frame) -> GameStateCell<T> {
-        //TODO: if lockstep, we still provide a single cell for saving. this should be replaced
-        if self.states.len() == 0 {
+        // if lockstep, we still provide a single cell for saving.
+        if self.max_pred == 0 {
             return self.states[0].clone();
         }
         assert!(frame >= 0);

--- a/tests/stubs_enum.rs
+++ b/tests/stubs_enum.rs
@@ -15,6 +15,7 @@ pub struct GameStubEnum {
 }
 use bytemuck::{CheckedBitPattern, NoUninit, Zeroable};
 
+#[allow(dead_code)]
 #[repr(u8)]
 #[derive(Copy, Clone, PartialEq, CheckedBitPattern, NoUninit)]
 pub enum EnumInput {


### PR DESCRIPTION
Fixes several bugs in the sync layer / input_queue logic. This now allows for max_prediction_window to be set to 0 and thus falling back to lockstep netcode (with unnecessary gamestate save requests).