### PR TITLE
feat: Remove GameStateCell's T: Clone requirement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ In this document, all remarkable changes are listed. Not mentioned are smaller c
 
 ## Unreleased
 
-- Nothing here yet...
+- allow non-`Clone` types to be stored in `GameStateCell`.
 
 ## 0.10.2
 

--- a/src/frame_info.rs
+++ b/src/frame_info.rs
@@ -3,7 +3,7 @@ use crate::{Frame, NULL_FRAME};
 /// Represents the game state of your game for a single frame. The `data` holds the game state, `frame` indicates the associated frame number
 /// and `checksum` can additionally be provided for use during a `SyncTestSession`.
 #[derive(Debug, Clone)]
-pub(crate) struct GameState<S: Clone> {
+pub(crate) struct GameState<S> {
     /// The frame to which this info belongs to.
     pub frame: Frame,
     /// The game state
@@ -12,7 +12,7 @@ pub(crate) struct GameState<S: Clone> {
     pub checksum: Option<u128>,
 }
 
-impl<S: Clone> Default for GameState<S> {
+impl<S> Default for GameState<S> {
     fn default() -> Self {
         Self {
             frame: NULL_FRAME,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -255,7 +255,7 @@ pub trait Config: 'static {
         + bytemuck::Zeroable;
 
     /// The save state type for the session.
-    type State: Clone;
+    type State;
 
     /// The address type which identifies the remote clients
     type Address: Clone + PartialEq + Eq + Hash + Debug;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,7 +17,7 @@ pub use sessions::builder::SessionBuilder;
 pub use sessions::p2p_session::P2PSession;
 pub use sessions::p2p_spectator_session::SpectatorSession;
 pub use sessions::sync_test_session::SyncTestSession;
-pub use sync_layer::GameStateCell;
+pub use sync_layer::{GameStateAccessor, GameStateCell};
 
 pub(crate) mod error;
 pub(crate) mod frame_info;


### PR DESCRIPTION
It turns out that the restriction of only storing cloneable things in `GameStateCell` is not actually necessary, since it's trivial for client code to do the actual cloning of the data stored in `GameStateCell` if they have access to it.
    
For convenience, to avoid breaking API, and to steer users away from the footgun of modifying a stored state, we still provide a `load()` function for the case where `T` is `Clone`.

---

This was originally motivated by me needing to clone a type which is faster to clone if I have a mutable reference to it; I could have used interior mutability via `UnsafeCell` but just out of interest I tried seeing if ggrs's `Clone` bound for game state could be relaxed, and it turns out that it can.

It seemed like a change that might be worth upstreaming since it simplies the code a little, and since bounds on impls are [often more ergonomic](https://stackoverflow.com/a/66369912/775982) than bounds on structs - and perhaps there are other niche use cases for being able to read data in a GameStateCell without cloning it that this enables too.

Note that this does have one downside: `MappedMutexGuard` becomes part of the public API, whereas before it was only an implementation detail. If that's a problem then the guard could be newtyped in a custom type with its own Deref(Mut) implementation, but I figure exposing the MappedMutexGuard directly is more flexible.