### PR TITLE
Bump example game macroquad to 0.4

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ js-sys = "0.3"
 [dev-dependencies]
 serial_test = "0.5"
 structopt = "0.3"
-macroquad = "0.3.10"
+macroquad = "0.4"
 
 # Examples
 [[example]]
@@ -44,4 +44,3 @@ path = "examples/ex_game/ex_game_spectator.rs"
 [[example]]
 name = "ex_game_synctest"
 path = "examples/ex_game/ex_game_synctest.rs"
-


### PR DESCRIPTION
Bump the example game to the latest macroquad version. There aren't any API changes that affect the demo so this is just a straightforward Cargo.toml change.

---

Macroquad 0.4 has been out for a bit now, and for whatever reason 0.4 compiles fine but 0.3 gets a linking error on my system. The linking error is almost certainly resolvable via installing the right system package dependencies etc, but bumping to Macroquad 0.4 has already fixed it, so I figure why not PR that to save someone else the hassle.

* Only tested on Linux (Fedora 40)...
* But I use Macroquad 0.4 for [my own](https://www.slowrush.dev/pixel-wizards-game/) game and that runs fine on Windows so I expect this will be just fine there too.
* Macroquad 0.4 did change a few things in MacOS land (a new Metal backend is available) so there is a tiny risk of something going wrong on that platform, but really, the API surface in use here is so small that we'd have to be really unlucky.. right?