### PR TITLE
Expose current frame in synctest and spectator sessions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ In this document, all remarkable changes are listed. Not mentioned are smaller c
 ## Unreleased
 
 - allow non-`Clone` types to be stored in `GameStateCell`.
+- added `SyncTestSession::current_frame()` and `SpectatorSession::current_frame()` to match the existing `P2PSession::current_frame()`
 
 ## 0.10.2
 

--- a/src/sessions/p2p_spectator_session.rs
+++ b/src/sessions/p2p_spectator_session.rs
@@ -165,6 +165,11 @@ impl<T: Config> SpectatorSession<T> {
         self.host.send_all_messages(&mut self.socket);
     }
 
+    /// Returns the current frame of a session.
+    pub fn current_frame(&self) -> Frame {
+        self.current_frame
+    }
+
     /// Returns the number of players this session was constructed with.
     pub fn num_players(&self) -> usize {
         self.num_players

--- a/src/sessions/sync_test_session.rs
+++ b/src/sessions/sync_test_session.rs
@@ -149,6 +149,11 @@ impl<T: Config> SyncTestSession<T> {
         Ok(requests)
     }
 
+    /// Returns the current frame of a session.
+    pub fn current_frame(&self) -> Frame {
+        self.sync_layer.current_frame()
+    }
+
     /// Returns the number of players this session was constructed with.
     pub fn num_players(&self) -> usize {
         self.num_players


### PR DESCRIPTION
`current_frame()` exists for p2p session currently, but the matching functions are missing for synctest or spectator sessions, so this adds them.

---

Adding these functions makes it easier to make a wrapper that abstracts over all types of sessions.