### PR TITLE
Allow reading P2PSession's current desync detection mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,8 @@ In this document, all remarkable changes are listed. Not mentioned are smaller c
 ## Unreleased
 
 - allow non-`Clone` types to be stored in `GameStateCell`.
-- added `SyncTestSession::current_frame()` and `SpectatorSession::current_frame()` to match the existing `P2PSession::current_frame()`
+- added `SyncTestSession::current_frame()` and `SpectatorSession::current_frame()` to match the existing `P2PSession::current_frame()`.
+- added `P2PSession::desync_detection()` to read the session's desync detection mode.
 
 ## 0.10.2
 

--- a/src/sessions/p2p_session.rs
+++ b/src/sessions/p2p_session.rs
@@ -571,6 +571,11 @@ impl<T: Config> P2PSession<T> {
         self.frames_ahead
     }
 
+    /// Returns the [`DesyncDetection`] mode set for this session at creation time.
+    pub fn desync_detection(&self) -> DesyncDetection {
+        self.desync_detection
+    }
+
     fn disconnect_player_at_frame(&mut self, player_handle: PlayerHandle, last_frame: Frame) {
         // disconnect the remote player
         match self


### PR DESCRIPTION
What it says on the tin.

---

Useful so I can calculate the checksum for game frames only when it's strictly necessary to have a checksum calculated.

I could instead store what I had set as the desync detection mode myself, but this is neater.