### PR TITLE
Fix desync detection false positive caused by a rollback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ In this document, all remarkable changes are listed. Not mentioned are smaller c
 - added `P2PSession::desync_detection()` to read the session's desync detection mode.
 - ggrs no longer panics when trying to send an overly large UDP packet, unless debug assertions are on.
 - fixed: ggrs would panic when trying to send a message over a custom socket implementation if that message exceeded the maximum safe UDP packet size, even though the underlying socket might have totally different applicable thresholds for what messages can be safely delivered.
+- fix a false positive in `P2PSession`'s desync detection; it was possible for a desync to incorrectly be detected when `P2PSession::advance_frame()` would 1. enqueue a checksum-changing rollback, 2. mark a to-be-rolled-back frame as confirmed, and 3. send that newly-confirmed frame's still-incorrect checksum to peers.
 
 ## 0.10.2
 


### PR DESCRIPTION
This fixes the case where the following happens:

1. Sync layer requests roll back to frame N
2. Sync layer requests advance to frame N+1
3. Sync layer marks frame N as confirmed
4. P2pSession's desync detection decides to send a checksum for frame N to peers, even though the checksum for frame N is now known to be incorrect (because ggrs-consuming-code has not had a chance to act on the advance frame request, so the checksum stored in frame N is from before the rollback).
5. Peers receive the incorrect checksum and flip out thinking there is a desync.

Actually causing this bug to reliably manifest in practice is somewhat tricky; I was able to reliably do it in my game via the following:

* high latencies (150ms on each client network interface, so 300ms round trip)
* input delay == 0
* desync detection interval set to 1
* start all game clients at once
* in the first advance, each client initially sends an input which is mispredicted by all other clients (so not the zeroed input).
* and lastly that first input from each client must modify the resulting checksum in a way that is unique from each other client's input.

The concrete input I am sending in my game is approximately equivalent to "store the client handle in the game state", but when I tried modifying the example game to do similar then it didn't manifest this bug - no idea why. In any case, this patch fixes the issue so I'll leave it at that.

It also changes a < to <= in a seemingly-isolated way; this change is based on the rationale given at
https://github.com/gschup/ggrs/pull/64/files#r1368265924 no longer applying.

---

cc @johanhelsing since at one point you were also somewhat familiar with this code thanks to https://github.com/gschup/ggrs/pull/64/ - although that was quite a while ago :)

Alternative approaches and why I didn't take them:

* "we can just skip sending a checksum if there's a rollback queued"
  * this is easy to detect because the first incorrect frame is easily accessible, but clients rely on receiving all checksums eventually so this isn't a good approach.
* "when we would send a checksum but there's already a rollback queued, instead remember that we need to send a checksum the next time advance_frame() is called"
  * this is functionally the same as what this patch does, except it would require some bookkeeping to keep track of "hey send a checksum next frame". Just moving the desync detection logic to the start of advance_frame() is neater overall.