### PR TITLE
Fix max rollback and lockstep handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ In this document, all remarkable changes are listed. Not mentioned are smaller c
 
 ## Unreleased
 
+- lockstep determinism is now possible by setting max predictions to 0
 - allow non-`Clone` types to be stored in `GameStateCell`.
 - added `SyncTestSession::current_frame()` and `SpectatorSession::current_frame()` to match the existing `P2PSession::current_frame()`.
 - added `P2PSession::desync_detection()` to read the session's desync detection mode.

--- a/examples/ex_game/ex_game.rs
+++ b/examples/ex_game/ex_game.rs
@@ -72,11 +72,23 @@ impl Game {
     }
 
     // for each request, call the appropriate function
-    pub fn handle_requests(&mut self, requests: Vec<GgrsRequest<GGRSConfig>>) {
+    pub fn handle_requests(&mut self, requests: Vec<GgrsRequest<GGRSConfig>>, in_lockstep: bool) {
         for request in requests {
             match request {
-                GgrsRequest::LoadGameState { cell, .. } => self.load_game_state(cell),
-                GgrsRequest::SaveGameState { cell, frame } => self.save_game_state(cell, frame),
+                GgrsRequest::LoadGameState { cell, .. } => {
+                    if in_lockstep {
+                        unreachable!("Should never get a load request if running in lockstep")
+                    } else {
+                        self.load_game_state(cell)
+                    }
+                }
+                GgrsRequest::SaveGameState { cell, frame } => {
+                    if in_lockstep {
+                        unreachable!("Should never get a save request if running in lockstep")
+                    } else {
+                        self.save_game_state(cell, frame)
+                    }
+                }
                 GgrsRequest::AdvanceFrame { inputs } => self.advance_frame(inputs),
             }
         }

--- a/examples/ex_game/ex_game_p2p.rs
+++ b/examples/ex_game/ex_game_p2p.rs
@@ -46,7 +46,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         // (optional) set expected update frequency
         .with_fps(FPS as usize)?
         // (optional) customize prediction window, which is how many frames ahead GGRS predicts.
-        // Or set the prediction window to 0 to fall back to lockstep netcode (with no rollbacks).
+        // Or set the prediction window to 0 to use lockstep netcode instead (i.e. no rollbacks).
         .with_max_prediction_window(8)
         // (optional) set input delay for the local player
         .with_input_delay(2)
@@ -119,7 +119,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 }
 
                 match sess.advance_frame() {
-                    Ok(requests) => game.handle_requests(requests),
+                    Ok(requests) => game.handle_requests(requests, sess.in_lockstep_mode()),
                     Err(e) => return Err(Box::new(e)),
                 }
             }

--- a/examples/ex_game/ex_game_p2p.rs
+++ b/examples/ex_game/ex_game_p2p.rs
@@ -45,10 +45,16 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .with_desync_detection_mode(ggrs::DesyncDetection::On { interval: 100 })
         // (optional) set expected update frequency
         .with_fps(FPS as usize)?
-        // secret trick: set the prediction to 0 to fall back to lockstep netcode
-        //.with_max_prediction_window(0)
+        // (optional) customize prediction window, which is how many frames ahead GGRS predicts.
+        // Or set the prediction window to 0 to fall back to lockstep netcode (with no rollbacks).
+        .with_max_prediction_window(8)
         // (optional) set input delay for the local player
-        .with_input_delay(2);
+        .with_input_delay(2)
+        // (optional) by default, GGRS will ask you to save the game state every frame. If your
+        // saving of game state takes much longer than advancing the game state N times, you can
+        // improve performance by turning sparse saving mode on (N == average number of predictions
+        // GGRS must make, which is determined by prediction window, FPS and latency to clients).
+        .with_sparse_saving_mode(false);
 
     // add players
     for (i, player_addr) in opt.players.iter().enumerate() {

--- a/examples/ex_game/ex_game_spectator.rs
+++ b/examples/ex_game/ex_game_spectator.rs
@@ -78,7 +78,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             // execute a frame
             if sess.current_state() == SessionState::Running {
                 match sess.advance_frame() {
-                    Ok(requests) => game.handle_requests(requests),
+                    Ok(requests) => game.handle_requests(requests, false),
                     Err(GgrsError::PredictionThreshold) => {
                         println!(
                             "Frame {} skipped: Waiting for input from host.",

--- a/examples/ex_game/ex_game_synctest.rs
+++ b/examples/ex_game/ex_game_synctest.rs
@@ -66,7 +66,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             }
 
             match sess.advance_frame() {
-                Ok(requests) => game.handle_requests(requests),
+                Ok(requests) => game.handle_requests(requests, false),
                 Err(e) => return Err(Box::new(e)),
             }
         }

--- a/src/sessions/builder.rs
+++ b/src/sessions/builder.rs
@@ -128,6 +128,19 @@ impl<T: Config> SessionBuilder<T> {
     }
 
     /// Change the maximum prediction window. Default is 8.
+    ///
+    /// ## Lockstep mode
+    ///
+    /// As a special case, if you set this to 0, GGRS will run in lockstep mode:
+    /// * ggrs will only request that you advance the gamestate if the current frame has inputs
+    ///   confirmed from all other clients.
+    /// * ggrs will never request you to save or roll back the gamestate.
+    ///
+    /// Lockstep mode can significantly reduce the (GGRS) framerate of your game, but may be
+    /// appropriate for games where a GGRS frame does not correspond to a rendered frame, such as a
+    /// game where GGRS frames are only advanced once a second; with input delay set to zero, the
+    /// framerate impact is approximately equivalent to taking the highest latency client and adding
+    /// its latency to the current time to tick a frame.
     pub fn with_max_prediction_window(mut self, window: usize) -> Self {
         self.max_prediction = window;
         self
@@ -145,9 +158,11 @@ impl<T: Config> SessionBuilder<T> {
         self
     }
 
-    /// Sets the sparse saving mode. With sparse saving turned on, only the minimum confirmed frame (for which all inputs from all players are confirmed correct) will be saved.
-    /// This leads to much less save requests at the cost of potentially longer rollbacks and thus more advance frame requests. Recommended, if saving your gamestate
-    /// takes much more time than advancing the game state.
+    /// Sets the sparse saving mode. With sparse saving turned on, only the minimum confirmed frame
+    /// (for which all inputs from all players are confirmed correct) will be saved. This leads to
+    /// much less save requests at the cost of potentially longer rollbacks and thus more advance
+    /// frame requests. Recommended, if saving your gamestate takes much more time than advancing
+    /// the game state.
     pub fn with_sparse_saving_mode(mut self, sparse_saving: bool) -> Self {
         self.sparse_saving = sparse_saving;
         self

--- a/src/sessions/p2p_session.rs
+++ b/src/sessions/p2p_session.rs
@@ -566,7 +566,7 @@ impl<T: Config> P2PSession<T> {
     ///
     /// In lockstep mode, a session will only advance if the current frame has inputs confirmed from
     /// all other players.
-    fn in_lockstep_mode(&mut self) -> bool {
+    pub fn in_lockstep_mode(&mut self) -> bool {
         self.max_prediction == 0
     }
 

--- a/src/sessions/p2p_session.rs
+++ b/src/sessions/p2p_session.rs
@@ -192,6 +192,15 @@ impl<T: Config> P2PSession<T> {
             SessionState::Synchronizing
         };
 
+        let sparse_saving = if max_prediction == 0 {
+            // in lockstep mode, saving will never happen, but we use the last saved frame to mark
+            // control marking frames confirmed, so we need to turn off sparse saving to ensure that
+            // frames are marked as confirmed - otherwise we will never advance the game state.
+            false
+        } else {
+            sparse_saving
+        };
+
         Self {
             state,
             num_players,
@@ -292,8 +301,13 @@ impl<T: Config> P2PSession<T> {
          * ROLLBACKS AND GAME STATE MANAGEMENT
          */
 
+        // if in lockstep mode, we will only ever request to advance the frame when all inputs for
+        // the current frame have been confirmed; therefore there's no need to roll back, and hence
+        // no need to ever save the game state either.
+        let lockstep = self.in_lockstep_mode();
+
         // if we are in the first frame, we have to save the state
-        if self.sync_layer.current_frame() == 0 {
+        if self.sync_layer.current_frame() == 0 && !lockstep {
             requests.push(self.sync_layer.save_current_state());
         }
 
@@ -303,22 +317,27 @@ impl<T: Config> P2PSession<T> {
         // find the confirmed frame for which we received all inputs
         let confirmed_frame = self.confirmed_frame();
 
-        // check game consistency and rollback, if necessary.
-        // The disconnect frame indicates if a rollback is necessary due to a previously disconnected player
-        let first_incorrect = self
-            .sync_layer
-            .check_simulation_consistency(self.disconnect_frame);
-        if first_incorrect != NULL_FRAME {
-            self.adjust_gamestate(first_incorrect, confirmed_frame, &mut requests);
-            self.disconnect_frame = NULL_FRAME;
-        }
+        // check game consistency and roll back, if necessary
+        if !lockstep {
+            // the disconnect frame indicates if a rollback is necessary due to a previously
+            // disconnected player (whose input would have been incorrectly predicted).
+            let first_incorrect = self
+                .sync_layer
+                .check_simulation_consistency(self.disconnect_frame);
+            // if we have an incorrect frame, then we need to rollback
+            if first_incorrect != NULL_FRAME {
+                self.adjust_gamestate(first_incorrect, confirmed_frame, &mut requests);
+                self.disconnect_frame = NULL_FRAME;
+            }
 
-        let last_saved = self.sync_layer.last_saved_frame();
-        if self.sparse_saving {
-            self.check_last_saved_state(last_saved, confirmed_frame, &mut requests);
-        } else {
-            // without sparse saving, always save the current frame after correcting and rollbacking
-            requests.push(self.sync_layer.save_current_state());
+            // request gamestate save of current frame
+            let last_saved = self.sync_layer.last_saved_frame();
+            if self.sparse_saving {
+                self.check_last_saved_state(last_saved, confirmed_frame, &mut requests);
+            } else {
+                // without sparse saving, always save the current frame after correcting and rollbacking
+                requests.push(self.sync_layer.save_current_state());
+            }
         }
 
         /*
@@ -371,10 +390,22 @@ impl<T: Config> P2PSession<T> {
          * ADVANCE THE STATE
          */
 
-        let frames_ahead = self.sync_layer.current_frame() - self.sync_layer.last_confirmed_frame();
-        if self.sync_layer.current_frame() < self.max_prediction as i32
-            || frames_ahead <= self.max_prediction as i32
-        {
+        let can_advance = if lockstep {
+            // lockstep mode: only advance if the current frame has inputs confirmed from all other
+            // players.
+            self.sync_layer.last_confirmed_frame() == self.sync_layer.current_frame()
+        } else {
+            // rollback mode: advance as long as we aren't past our prediction window
+            let frames_ahead = if self.sync_layer.last_confirmed_frame() == NULL_FRAME {
+                // we haven't had any frames confirmed, so all frames we've advanced are "ahead"
+                self.sync_layer.current_frame()
+            } else {
+                // we're not at the first frame, so we have to subtract the last confirmed frame
+                self.sync_layer.current_frame() - self.sync_layer.last_confirmed_frame()
+            };
+            frames_ahead < self.max_prediction as i32
+        };
+        if can_advance {
             // get correct inputs for the current frame
             let inputs = self
                 .sync_layer
@@ -529,6 +560,14 @@ impl<T: Config> P2PSession<T> {
     /// Returns the maximum prediction window of a session.
     pub fn max_prediction(&self) -> usize {
         self.max_prediction
+    }
+
+    /// Returns true if the session is running in lockstep mode.
+    ///
+    /// In lockstep mode, a session will only advance if the current frame has inputs confirmed from
+    /// all other players.
+    fn in_lockstep_mode(&mut self) -> bool {
+        self.max_prediction == 0
     }
 
     /// Returns the current [`SessionState`] of a session.

--- a/src/sync_layer.rs
+++ b/src/sync_layer.rs
@@ -228,10 +228,20 @@ impl<T: Config> SyncLayer<T> {
     /// Loads the gamestate indicated by `frame_to_load`.
     pub(crate) fn load_frame(&mut self, frame_to_load: Frame) -> GgrsRequest<T> {
         // The state should not be the current state or the state should not be in the future or too far away in the past
+        assert!(frame_to_load != NULL_FRAME, "cannot load null frame");
         assert!(
-            frame_to_load != NULL_FRAME
-                && frame_to_load < self.current_frame
-                && frame_to_load >= self.current_frame - self.max_prediction as i32
+            frame_to_load < self.current_frame,
+            "must load frame in the past (frame to load is {}, current frame is {})",
+            frame_to_load,
+            self.current_frame
+        );
+        assert!(
+            frame_to_load >= self.current_frame - self.max_prediction as i32,
+            "cannot load frame outside of prediction window; \
+            (frame to load is {}, current frame is {}, max prediction is {})",
+            frame_to_load,
+            self.current_frame,
+            self.max_prediction
         );
 
         let cell = self.saved_states.get_cell(frame_to_load);

--- a/src/sync_layer.rs
+++ b/src/sync_layer.rs
@@ -143,29 +143,22 @@ impl<'c, T> GameStateAccessor<'c, T> {
 
 pub(crate) struct SavedStates<T> {
     pub states: Vec<GameStateCell<T>>,
-    max_pred: usize,
 }
 
 impl<T> SavedStates<T> {
     fn new(max_pred: usize) -> Self {
-        let mut states = Vec::with_capacity(max_pred);
-        for _ in 0..max_pred {
+        // we need to store the current frame plus the number of max predictions, so that we can
+        // roll back to the very first frame even when we have predicted as far ahead as we can.
+        let num_cells = max_pred + 1;
+        let mut states = Vec::with_capacity(num_cells);
+        for _ in 0..num_cells {
             states.push(GameStateCell::default());
         }
 
-        // if lockstep, we still provide a single cell for saving.
-        if max_pred == 0 {
-            states.push(GameStateCell::default());
-        }
-
-        Self { states, max_pred }
+        Self { states }
     }
 
     fn get_cell(&self, frame: Frame) -> GameStateCell<T> {
-        // if lockstep, we still provide a single cell for saving.
-        if self.max_pred == 0 {
-            return self.states[0].clone();
-        }
         assert!(frame >= 0);
         let pos = frame as usize % self.states.len();
         self.states[pos].clone()


### PR DESCRIPTION
NB: This builds on PR #82 so we better merge that one first to make this diff easier to review. (is Github working on [stacked diff](https://www.stacking.dev/) support yet?)

---

This fixes several issues that (I am fairly certain) came from merging #79:

* When at the limit of the prediction window, rolling back would crash. This is fairly easy to trigger by adding a lot of latency in a network simulator. The cause was an off by one error in SavedStates' calculation of how many states need to be saved.
* Clearer logic controlling when it's okay to request advancing the frame. I am not 100% certain but I suspect that the #79 logic wasn't handling `NULL_FRAME` correctly? In any case I think this new structure makes it a lot easier to reason about.
* Lockstep mode specific stuff:
  * Document lockstep mode as first class thing.
  * Fix disconnect handling in lockstep mode; previously the game would crash if a player disconnects (trying to rollback to the current frame, or perhaps the frame before the current? I can't quite remember). The fix is to skip all the "should we roll back" logic entirely if lockstep mode is on.
  * Make lockstep mode not issue save requests ever, since that's pointless - and besides, the fix for the previous bullet makes this almost necessary.
    * Because of this, we also need to turn off sparse saving mode in lockstep mode, since sparse saving mode somewhat confusingly causes us to not mark frames as confirmed, and not having frames confirmed means we won't advance.
    * Update example to more easily catch the case where lockstep mode is on but somehow we got issued a save or rollback request, by panicking in that case.

I have tested manually with 2 and 3 player example games, with lockstep mode and 8 frames of prediction and with sparse saving on and off. In a previous version of these fixes (those on the main branch of my personal fork) I also did a lot of testing with high latency and such to verify the "rollback when at limit of prediction window" fix, but in the name of full disclosure, I haven't done that with this branch specifically (I have a smallish test harness that makes it easy to do that testing with my game and my ggrs fork).

Anyway, based on that testing, everything seems to work.. but this is fiddly stuff so :crossed_fingers:. I am at least pretty confident that it's more reliable than what's in `main` currently :) 