### PR TITLE
Add tracing for logging

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,8 @@ rand = "0.8"
 bitfield-rle = "0.2.1"
 parking_lot = "0.12"
 instant = "0.1"
-getrandom = {version = "0.2", optional = true}
+getrandom = { version = "0.2", optional = true }
+tracing = "0.1"
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 js-sys = "0.3"
@@ -29,7 +30,9 @@ js-sys = "0.3"
 [dev-dependencies]
 serial_test = "0.5"
 structopt = "0.3"
-macroquad = "0.4"
+macroquad = { version = "0.4", features = ["log-rs"] }
+tracing-subscriber = "0.3"
+tracing-log = "0.2"
 
 # Examples
 [[example]]

--- a/examples/ex_game/ex_game_p2p.rs
+++ b/examples/ex_game/ex_game_p2p.rs
@@ -33,6 +33,16 @@ struct Opt {
 
 #[macroquad::main(window_conf)]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // configure logging: output ggrs and example game logs to standard out
+    tracing::subscriber::set_global_default(
+        tracing_subscriber::FmtSubscriber::builder()
+            .with_max_level(tracing::Level::DEBUG)
+            .finish(),
+    )
+    .expect("setting up tracing subscriber failed");
+    // forward logs from log crate to the tracing subscriber (allows seeing macroquad logs)
+    tracing_log::LogTracer::init()?;
+
     // read cmd line arguments
     let opt = Opt::from_args();
     let num_players = opt.players.len();
@@ -91,7 +101,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
         // print GGRS events
         for event in sess.events() {
-            println!("Event: {:?}", event);
+            info!("Event: {:?}", event);
         }
 
         // this is to keep ticks between clients synchronized.

--- a/examples/ex_game/ex_game_synctest.rs
+++ b/examples/ex_game/ex_game_synctest.rs
@@ -30,6 +30,16 @@ struct Opt {
 
 #[macroquad::main(window_conf)]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // configure logging: output ggrs and example game logs to standard out
+    tracing::subscriber::set_global_default(
+        tracing_subscriber::FmtSubscriber::builder()
+            .with_max_level(tracing::Level::DEBUG)
+            .finish(),
+    )
+    .expect("setting up tracing subscriber failed");
+    // forward logs from log crate to the tracing subscriber (allows seeing macroquad logs)
+    tracing_log::LogTracer::init()?;
+
     // read cmd line arguments
     let opt = Opt::from_args();
 

--- a/src/network/messages.rs
+++ b/src/network/messages.rs
@@ -27,7 +27,7 @@ pub(crate) struct SyncReply {
     pub random_reply: u32, // here's your random data back
 }
 
-#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub(crate) struct Input {
     pub peer_connect_status: Vec<ConnectionStatus>,
     pub disconnect_requested: bool,
@@ -45,6 +45,29 @@ impl Default for Input {
             ack_frame: NULL_FRAME,
             bytes: Vec::new(),
         }
+    }
+}
+
+impl std::fmt::Debug for Input {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Input")
+            .field("peer_connect_status", &self.peer_connect_status)
+            .field("disconnect_requested", &self.disconnect_requested)
+            .field("start_frame", &self.start_frame)
+            .field("ack_frame", &self.ack_frame)
+            .field("bytes", &BytesDebug(&self.bytes))
+            .finish()
+    }
+}
+struct BytesDebug<'a>(&'a [u8]);
+
+impl<'a> std::fmt::Debug for BytesDebug<'a> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str("0x")?;
+        for byte in self.0 {
+            write!(f, "{:02x}", byte)?;
+        }
+        Ok(())
     }
 }
 

--- a/src/network/udp_socket.rs
+++ b/src/network/udp_socket.rs
@@ -3,6 +3,8 @@ use std::{
     net::{IpAddr, Ipv4Addr, SocketAddr, UdpSocket},
 };
 
+use tracing::warn;
+
 use crate::{network::messages::Message, NonBlockingSocket};
 
 const RECV_BUFFER_SIZE: usize = 4096;
@@ -47,12 +49,9 @@ impl NonBlockingSocket<SocketAddr> for UdpNonBlockingSocket {
         //
         // On the other hand, the occaisional large packet is kind of harmless - whether it gets
         // fragmented or not, the odds are that it will get through unless the connection is truly
-        // horrible.
-        //
-        // So ideally we'd inform the user by logging a warning, but we don't have any logging set
-        // up - so as a compromise, we ignore this in release mode but panic in debug mode.
-        if buf.len() > IDEAL_MAX_UDP_PACKET_SIZE && cfg!(debug_assertions) {
-            panic!(
+        // horrible. So, we'll just log a warning.
+        if buf.len() > IDEAL_MAX_UDP_PACKET_SIZE {
+            warn!(
                 "Sending UDP packet of size {} bytes, which is \
                 larger than ideal ({IDEAL_MAX_UDP_PACKET_SIZE})",
                 buf.len()


### PR DESCRIPTION
Closes #89.

I already had 90% of this implemented on my ggrs fork so I figured I'd just push it up and see if you were happy to go with `tracing` as the log choice. (If you prefer using `log`'s API instead, I'm happy to rework this to do that instead.)

Summary of changes:
* Add tracing dependency to library, and tracing_subscriber + tracing_log for dev deps so we can use them in examples and have all logs going to one place. (Importantly, we need to use tracing_log and turn on macroquad's log_rs feature to ensure that macroquad's logs - which includes our info!/etc logs because we import macroquad's prelude - get routed to tracing)
* Fix the specific cases mentioned in #89 :
  * Fix the println in advance_frame()
  * Don't panic in debug mode on large UDP packet sizes anymore - just warn!() instead (in both debug and release mode)
  * Warn when sparse saving is enabled in lockstep mode
* Add various logging calls that I found useful in my own dev work on ggrs - most notably, trace logging for all network traffic has been really useful.
* Add custom debug impl for `Input` that prints the Input's bytes in hex, so that Input messages are a tiny bit more understandable

Also includes one tiny non-logging change of an error message format (will call it out in a separate comment).