### PR TITLE
feat: SyncTestSession GgrsEvent::MismatchedChecksum

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -165,6 +165,15 @@ where
         /// remote address of the endpoint.
         addr: T::Address,
     },
+    /// In a [`SyncTestSession`], sent whenever the checksums of resimulated frames do not match up with the original checksum.
+    ///
+    /// [`SyncTestSession`]: crate::SyncTestSession
+    MismatchedChecksum {
+        /// The frame at which the mismatch occurred.
+        current_frame: Frame,
+        /// The oldest frame with mismatched checksum
+        mismatched_frame: Frame,
+    },
 }
 
 /// Requests that you can receive from the session. Handling them is mandatory.

--- a/src/sessions/builder.rs
+++ b/src/sessions/builder.rs
@@ -344,6 +344,7 @@ impl<T: Config> SessionBuilder<T> {
     /// Due to the decentralized nature of saving and loading gamestates, checksum comparisons can only be made if `check_distance` is 2 or higher.
     /// This is a great way to test if your system runs deterministically.
     /// After creating the session, add a local player, set input delay for them and then start the session.
+    /// Optionally, inspect [`SyncTestSession.events`] to detect events such as [`GgrsEvent::MismatchedChecksum`].
     pub fn start_synctest_session(self) -> Result<SyncTestSession<T>, GgrsError> {
         if self.check_dist >= self.max_prediction {
             return Err(GgrsError::InvalidRequest {


### PR DESCRIPTION
SyncTestSession will expose events similar to P2PSession allowing consumers to handle events such as MismatchedCheckum.

Suggested minor enhancement for SyncTestSession after [discussions](https://discord.com/channels/631682418532941824/634161779102187530/1319813481406398604) with @caspark.

I am FAR from having my head around GGRS, so forgive my fumbling. Note I added a variant to the GgrsEvent enum, which would cause problems to any previously exhaustive match, for example.