### PR TITLE
Allow simple enums in Input

### DIFF
--- a/src/network/protocol.rs
+++ b/src/network/protocol.rs
@@ -54,7 +54,8 @@ struct InputBytes {
 
 impl InputBytes {
     fn zeroed<T: Config>(num_players: usize) -> Self {
-        let size = core::mem::size_of::<T::Input>() * num_players;
+        let input_size = bincode::serialized_size(&T::Input::default()).expect("input serialization failed");
+        let size = (input_size as usize) * num_players;
         Self {
             frame: NULL_FRAME,
             bytes: vec![0; size],

--- a/src/network/protocol.rs
+++ b/src/network/protocol.rs
@@ -54,7 +54,8 @@ struct InputBytes {
 
 impl InputBytes {
     fn zeroed<T: Config>(num_players: usize) -> Self {
-        let input_size = bincode::serialized_size(&T::Input::default()).expect("input serialization failed");
+        let input_size =
+            bincode::serialized_size(&T::Input::default()).expect("input serialization failed");
         let size = (input_size as usize) * num_players;
         Self {
             frame: NULL_FRAME,

--- a/tests/test_p2p_session_enum.rs
+++ b/tests/test_p2p_session_enum.rs
@@ -1,0 +1,75 @@
+mod stubs_enum;
+
+use ggrs::{GgrsError, PlayerType, SessionBuilder, SessionState, UdpNonBlockingSocket};
+use serial_test::serial;
+use std::net::{IpAddr, Ipv4Addr, SocketAddr};
+use stubs_enum::{EnumInput, GameStubEnum, StubEnumConfig};
+
+#[test]
+#[serial]
+fn test_advance_frame_p2p_sessions_enum() -> Result<(), GgrsError> {
+    let addr1 = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 7777);
+    let addr2 = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 8888);
+
+    let socket1 = UdpNonBlockingSocket::bind_to_port(7777).unwrap();
+    let mut sess1 = SessionBuilder::<StubEnumConfig>::new()
+        .add_player(PlayerType::Local, 0)?
+        .add_player(PlayerType::Remote(addr2), 1)?
+        .start_p2p_session(socket1)?;
+
+    let socket2 = UdpNonBlockingSocket::bind_to_port(8888).unwrap();
+    let mut sess2 = SessionBuilder::<StubEnumConfig>::new()
+        .add_player(PlayerType::Remote(addr1), 0)?
+        .add_player(PlayerType::Local, 1)?
+        .start_p2p_session(socket2)?;
+
+    assert!(sess1.current_state() == SessionState::Synchronizing);
+    assert!(sess2.current_state() == SessionState::Synchronizing);
+
+    for _ in 0..50 {
+        sess1.poll_remote_clients();
+        sess2.poll_remote_clients();
+    }
+
+    assert!(sess1.current_state() == SessionState::Running);
+    assert!(sess2.current_state() == SessionState::Running);
+
+    let mut stub1 = GameStubEnum::new();
+    let mut stub2 = GameStubEnum::new();
+    let reps = 10;
+    for i in 0..reps {
+        sess1.poll_remote_clients();
+        sess2.poll_remote_clients();
+
+        sess1
+            .add_local_input(
+                0,
+                if i % 2 == 0 {
+                    EnumInput::Val1
+                } else {
+                    EnumInput::Val2
+                },
+            )
+            .unwrap();
+        let requests1 = sess1.advance_frame().unwrap();
+        stub1.handle_requests(requests1);
+        sess2
+            .add_local_input(
+                1,
+                if i % 3 == 0 {
+                    EnumInput::Val1
+                } else {
+                    EnumInput::Val2
+                },
+            )
+            .unwrap();
+        let requests2 = sess2.advance_frame().unwrap();
+        stub2.handle_requests(requests2);
+
+        // gamestate evolves
+        assert_eq!(stub1.gs.frame, i as i32 + 1);
+        assert_eq!(stub2.gs.frame, i as i32 + 1);
+    }
+
+    Ok(())
+}


### PR DESCRIPTION
The code for setting up the input buffers currently causes a crash when getting enums for input because it calculates the size of the input using `core::mem::size_of()` instead of bincode, which have different results. I wrote a new test to demonstrate the issue. Without the changes in this PR, it panics:

![image](https://github.com/user-attachments/assets/305e30e6-5bbd-41ea-b74b-15ebd7761357)

By updating the initial size to use bincode::serialized_size(&T::Input::default()), the problem is fixed. This does not solve for cases when the enum variants have data and are encoded to different sized, which would require a much larger change.