### PR TITLE
test: unit tests for internals

### DIFF
--- a/src/frame_info.rs
+++ b/src/frame_info.rs
@@ -86,4 +86,26 @@ mod game_input_tests {
         let input2 = PlayerInput::new(0, TestInput { inp: 7 });
         assert!(!input1.equal(&input2, false)); // different bits
     }
+
+    #[test]
+    fn test_input_equality_frame_mismatch_not_input_only() {
+        // same input, different frames — with input_only=false this should be false
+        let input1 = PlayerInput::new(0, TestInput { inp: 5 });
+        let input2 = PlayerInput::new(1, TestInput { inp: 5 });
+        assert!(!input1.equal(&input2, false));
+    }
+
+    #[test]
+    fn test_blank_input() {
+        let input = PlayerInput::<TestInput>::blank_input(7);
+        assert_eq!(input.frame, 7);
+        assert_eq!(input.input.inp, 0);
+    }
+
+    #[test]
+    fn test_new_stores_frame_and_input() {
+        let input = PlayerInput::new(42, TestInput { inp: 99 });
+        assert_eq!(input.frame, 42);
+        assert_eq!(input.input.inp, 99);
+    }
 }

--- a/src/input_queue.rs
+++ b/src/input_queue.rs
@@ -324,4 +324,98 @@ mod input_queue_tests {
             assert_eq!(input_in_queue.inp, correct_input);
         }
     }
+
+    #[test]
+    fn test_prediction_returned_for_missing_frame() {
+        let mut queue = InputQueue::<TestConfig>::new();
+        let input = PlayerInput::new(0, TestInput { inp: 42 });
+        queue.add_input(input);
+        // frame 1 has not been added yet — should get a prediction
+        let (_inp, status) = queue.input(1);
+        assert_eq!(status, InputStatus::Predicted);
+    }
+
+    #[test]
+    fn test_prediction_repeats_last_input() {
+        let mut queue = InputQueue::<TestConfig>::new();
+        let input = PlayerInput::new(0, TestInput { inp: 77 });
+        queue.add_input(input);
+        // prediction should repeat the last real input
+        let (predicted, _status) = queue.input(1);
+        assert_eq!(predicted.inp, 77);
+    }
+
+    #[test]
+    fn test_confirmed_input_after_prediction_no_mismatch() {
+        let mut queue = InputQueue::<TestConfig>::new();
+        queue.add_input(PlayerInput::new(0, TestInput { inp: 5 }));
+        // trigger prediction for frame 1
+        queue.input(1);
+        // now add the real input for frame 1 matching the prediction
+        queue.add_input(PlayerInput::new(1, TestInput { inp: 5 }));
+        assert_eq!(queue.first_incorrect_frame(), NULL_FRAME);
+    }
+
+    #[test]
+    fn test_first_incorrect_frame_tracked_on_mismatch() {
+        let mut queue = InputQueue::<TestConfig>::new();
+        queue.add_input(PlayerInput::new(0, TestInput { inp: 5 }));
+        // trigger prediction for frame 1 (predicts inp=5)
+        queue.input(1);
+        // add real input for frame 1 that differs from prediction
+        queue.add_input(PlayerInput::new(1, TestInput { inp: 99 }));
+        assert_eq!(queue.first_incorrect_frame(), 1);
+    }
+
+    #[test]
+    fn test_reset_prediction_clears_state() {
+        let mut queue = InputQueue::<TestConfig>::new();
+        queue.add_input(PlayerInput::new(0, TestInput { inp: 5 }));
+        queue.input(1);
+        queue.add_input(PlayerInput::new(1, TestInput { inp: 99 }));
+        assert_eq!(queue.first_incorrect_frame(), 1);
+
+        queue.reset_prediction();
+
+        assert_eq!(queue.first_incorrect_frame(), NULL_FRAME);
+        assert_eq!(queue.last_requested_frame, NULL_FRAME);
+    }
+
+    #[test]
+    fn test_confirmed_input_returns_correct_value() {
+        let mut queue = InputQueue::<TestConfig>::new();
+        for i in 0..6 {
+            queue.add_input(PlayerInput::new(i, TestInput { inp: i as u8 * 10 }));
+        }
+        let confirmed = queue.confirmed_input(3);
+        assert_eq!(confirmed.frame, 3);
+        assert_eq!(confirmed.input.inp, 30);
+    }
+
+    #[test]
+    fn test_discard_confirmed_frames_reduces_length() {
+        let mut queue = InputQueue::<TestConfig>::new();
+        for i in 0..10 {
+            queue.add_input(PlayerInput::new(i, TestInput { inp: i as u8 }));
+        }
+        let len_before = queue.length;
+        queue.discard_confirmed_frames(5);
+        assert!(queue.length < len_before);
+    }
+
+    #[test]
+    fn test_queue_wraps_around_without_panic() {
+        let mut queue = InputQueue::<TestConfig>::new();
+        // INPUT_QUEUE_LENGTH is 128. Add frames in batches, discarding confirmed frames
+        // between batches to keep the queue from filling up. This exercises the circular
+        // index wraparound path.
+        for i in 0..200_i32 {
+            let result = queue.add_input(PlayerInput::new(i, TestInput { inp: i as u8 }));
+            assert_ne!(result, NULL_FRAME, "frame {i} should have been accepted");
+            // discard every 64 frames so the queue never exceeds INPUT_QUEUE_LENGTH
+            if i > 0 && i % 64 == 0 {
+                queue.discard_confirmed_frames(i - 1);
+            }
+        }
+    }
 }

--- a/src/network/compression.rs
+++ b/src/network/compression.rs
@@ -80,4 +80,41 @@ mod compression_tests {
 
         assert!(pend_inp == decoded);
     }
+
+    #[test]
+    fn test_encode_decode_identical_to_reference() {
+        // When inputs are identical to the reference, delta is all-zeros — good for RLE
+        let reference = vec![1, 2, 3, 4];
+        let inputs = vec![reference.clone(), reference.clone()];
+        let encoded = encode(&reference, inputs.iter());
+        let decoded = decode(&reference, &encoded).unwrap();
+        assert_eq!(decoded, inputs);
+    }
+
+    #[test]
+    fn test_encode_decode_single_input() {
+        let reference = vec![0u8; 4];
+        let inputs = vec![vec![1u8, 2, 3, 4]];
+        let encoded = encode(&reference, inputs.iter());
+        let decoded = decode(&reference, &encoded).unwrap();
+        assert_eq!(decoded, inputs);
+    }
+
+    #[test]
+    fn test_encode_decode_all_zeros() {
+        let reference = vec![0u8; 4];
+        let inputs = vec![vec![0u8; 4], vec![0u8; 4], vec![0u8; 4]];
+        let encoded = encode(&reference, inputs.iter());
+        let decoded = decode(&reference, &encoded).unwrap();
+        assert_eq!(decoded, inputs);
+    }
+
+    #[test]
+    fn test_delta_encode_decode_in_isolation() {
+        let reference = vec![0xAA, 0xBB];
+        let inputs = vec![vec![0xFF, 0x00], vec![0x00, 0xFF]];
+        let encoded = delta_encode(&reference, inputs.iter());
+        let decoded = delta_decode(&reference, &encoded);
+        assert_eq!(decoded, inputs);
+    }
 }

--- a/src/sync_layer.rs
+++ b/src/sync_layer.rs
@@ -399,6 +399,61 @@ mod sync_layer_tests {
         type Address = SocketAddr;
     }
 
+    // GameStateCell tests
+
+    #[test]
+    fn test_cell_default_frame_is_null() {
+        let cell = GameStateCell::<u8>::default();
+        assert_eq!(cell.frame(), NULL_FRAME);
+    }
+
+    #[test]
+    fn test_cell_save_and_frame() {
+        let cell = GameStateCell::<u8>::default();
+        cell.save(5, Some(42u8), None);
+        assert_eq!(cell.frame(), 5);
+    }
+
+    #[test]
+    fn test_cell_save_and_checksum() {
+        let cell = GameStateCell::<u8>::default();
+        cell.save(1, Some(0u8), Some(0xDEADBEEF));
+        assert_eq!(cell.checksum(), Some(0xDEADBEEF));
+    }
+
+    #[test]
+    fn test_cell_data_returns_none_before_save() {
+        let cell = GameStateCell::<u8>::default();
+        assert!(cell.data().is_none());
+    }
+
+    #[test]
+    fn test_cell_data_returns_some_after_save() {
+        let cell = GameStateCell::<u8>::default();
+        cell.save(1, Some(99u8), None);
+        let accessor = cell.data().expect("should have data");
+        assert_eq!(*accessor, 99u8);
+    }
+
+    #[test]
+    fn test_cell_load_clones_value() {
+        let cell = GameStateCell::<u8>::default();
+        cell.save(1, Some(77u8), None);
+        assert_eq!(cell.load(), Some(77u8));
+    }
+
+    #[test]
+    fn test_cell_clone_shares_state() {
+        let cell = GameStateCell::<u8>::default();
+        let clone = cell.clone();
+        cell.save(3, Some(55u8), None);
+        // clone shares the Arc, so it should see the saved state
+        assert_eq!(clone.frame(), 3);
+        assert_eq!(clone.load(), Some(55u8));
+    }
+
+    // SyncLayer tests
+
     #[test]
     fn test_different_delays() {
         let mut sync_layer = SyncLayer::<TestConfig>::new(2, 8);
@@ -430,5 +485,138 @@ mod sync_layer_tests {
 
             sync_layer.advance_frame();
         }
+    }
+
+    fn make_connect_status(n: usize) -> Vec<ConnectionStatus> {
+        vec![ConnectionStatus::default(); n]
+    }
+
+    #[test]
+    fn test_advance_frame_increments_current_frame() {
+        let mut sync_layer = SyncLayer::<TestConfig>::new(1, 8);
+        assert_eq!(sync_layer.current_frame(), 0);
+        sync_layer.advance_frame();
+        assert_eq!(sync_layer.current_frame(), 1);
+    }
+
+    #[test]
+    fn test_save_current_state_updates_last_saved_frame() {
+        let mut sync_layer = SyncLayer::<TestConfig>::new(1, 8);
+        let req = sync_layer.save_current_state();
+        assert_eq!(sync_layer.last_saved_frame(), 0);
+        // fulfill the save request so the cell contains frame 0
+        if let GgrsRequest::SaveGameState { cell, frame } = req {
+            cell.save(frame, Some(0u8), None);
+        }
+    }
+
+    #[test]
+    fn test_saved_state_by_frame_returns_none_before_save() {
+        let sync_layer = SyncLayer::<TestConfig>::new(1, 8);
+        assert!(sync_layer.saved_state_by_frame(0).is_none());
+    }
+
+    #[test]
+    fn test_saved_state_by_frame_returns_some_after_save() {
+        let mut sync_layer = SyncLayer::<TestConfig>::new(1, 8);
+        let req = sync_layer.save_current_state();
+        if let GgrsRequest::SaveGameState { cell, frame } = req {
+            cell.save(frame, Some(7u8), None);
+        }
+        assert!(sync_layer.saved_state_by_frame(0).is_some());
+    }
+
+    #[test]
+    fn test_load_frame_rewinds_current_frame() {
+        let mut sync_layer = SyncLayer::<TestConfig>::new(1, 8);
+        // save frame 0
+        let req = sync_layer.save_current_state();
+        if let GgrsRequest::SaveGameState { cell, frame } = req {
+            cell.save(frame, Some(0u8), None);
+        }
+        // advance to frame 3
+        sync_layer.advance_frame();
+        sync_layer.advance_frame();
+        sync_layer.advance_frame();
+        assert_eq!(sync_layer.current_frame(), 3);
+        // load frame 0
+        let _req = sync_layer.load_frame(0);
+        assert_eq!(sync_layer.current_frame(), 0);
+    }
+
+    #[test]
+    fn test_check_simulation_consistency_no_mismatch() {
+        let mut sync_layer = SyncLayer::<TestConfig>::new(2, 8);
+        let connect_status = make_connect_status(2);
+        for i in 0..5 {
+            let inp = PlayerInput::new(i, TestInput { inp: i as u8 });
+            sync_layer.add_remote_input(0, inp);
+            sync_layer.add_remote_input(1, inp);
+            sync_layer.synchronized_inputs(&connect_status);
+            sync_layer.advance_frame();
+        }
+        assert_eq!(
+            sync_layer.check_simulation_consistency(NULL_FRAME),
+            NULL_FRAME
+        );
+    }
+
+    #[test]
+    fn test_check_simulation_consistency_finds_mismatch() {
+        let mut sync_layer = SyncLayer::<TestConfig>::new(1, 8);
+        // Add frame 0, then request frame 1 to trigger a prediction
+        sync_layer.add_remote_input(0, PlayerInput::new(0, TestInput { inp: 5 }));
+        let connect_status = make_connect_status(1);
+        sync_layer.synchronized_inputs(&connect_status); // requests frame 0
+        sync_layer.advance_frame();
+        sync_layer.synchronized_inputs(&connect_status); // requests frame 1 → prediction
+                                                         // Now add real frame 1 (player 0) with a different value to cause a mismatch
+        sync_layer.add_remote_input(0, PlayerInput::new(1, TestInput { inp: 99 }));
+        assert_eq!(sync_layer.check_simulation_consistency(NULL_FRAME), 1);
+    }
+
+    #[test]
+    fn test_set_last_confirmed_frame_updates_last_confirmed() {
+        let mut sync_layer = SyncLayer::<TestConfig>::new(1, 8);
+        for i in 0..10 {
+            sync_layer.add_remote_input(0, PlayerInput::new(i, TestInput { inp: i as u8 }));
+            sync_layer.advance_frame();
+        }
+        sync_layer.set_last_confirmed_frame(5, false);
+        assert_eq!(sync_layer.last_confirmed_frame(), 5);
+    }
+
+    #[test]
+    fn test_set_last_confirmed_frame_sparse_saving_caps_at_last_saved() {
+        let mut sync_layer = SyncLayer::<TestConfig>::new(1, 8);
+        // save frame 0
+        let req = sync_layer.save_current_state();
+        if let GgrsRequest::SaveGameState { cell, frame } = req {
+            cell.save(frame, Some(0u8), None);
+        }
+        // advance several frames without saving
+        for i in 0..5 {
+            sync_layer.add_remote_input(0, PlayerInput::new(i, TestInput { inp: 0 }));
+            sync_layer.advance_frame();
+        }
+        // with sparse_saving=true, confirmed frame should be capped at last_saved_frame (0)
+        sync_layer.set_last_confirmed_frame(4, true);
+        assert_eq!(sync_layer.last_confirmed_frame(), 0);
+    }
+
+    #[test]
+    fn test_disconnected_player_returns_default_input() {
+        let mut sync_layer = SyncLayer::<TestConfig>::new(2, 8);
+        let mut connect_status = make_connect_status(2);
+        // mark player 1 as disconnected before frame 0
+        connect_status[1].disconnected = true;
+        connect_status[1].last_frame = -1;
+        // provide input only for player 0
+        sync_layer.add_remote_input(0, PlayerInput::new(0, TestInput { inp: 42 }));
+
+        let inputs = sync_layer.synchronized_inputs(&connect_status);
+        assert_eq!(inputs[0].1, InputStatus::Confirmed);
+        assert_eq!(inputs[1].1, InputStatus::Disconnected);
+        assert_eq!(inputs[1].0.inp, 0); // default
     }
 }

--- a/src/time_sync.rs
+++ b/src/time_sync.rs
@@ -112,4 +112,41 @@ mod sync_layer_tests {
 
         assert_eq!(time_sync.average_frame_advantage(), 40);
     }
+
+    #[test]
+    fn test_window_wraparound_uses_only_recent_frames() {
+        // FRAME_WINDOW_SIZE is 30. Fill 60 frames: first 30 with advantage 10,
+        // second 30 (which overwrite them) with advantage 0. Result should be 0.
+        let mut time_sync = TimeSync::default();
+        for i in 0..30 {
+            time_sync.advance_frame(i, -10, 10); // advantage = 10
+        }
+        for i in 30..60 {
+            time_sync.advance_frame(i, 0, 0); // advantage = 0, overwrites slots
+        }
+        assert_eq!(time_sync.average_frame_advantage(), 0);
+    }
+
+    #[test]
+    fn test_partial_window_includes_zero_initialized_slots() {
+        // Only fill 10 of 30 slots with advantage 30 (local=-30, remote=30).
+        // The other 20 slots are zero-initialized.
+        // Expected: ((10 * 30 + 20 * 0) / 30 - (10 * -30 + 20 * 0) / 30) / 2
+        //         = (10 - (-10)) / 2 = 10
+        let mut time_sync = TimeSync::default();
+        for i in 0..10 {
+            time_sync.advance_frame(i, -30, 30);
+        }
+        assert_eq!(time_sync.average_frame_advantage(), 10);
+    }
+
+    #[test]
+    fn test_asymmetric_advantages() {
+        // local_adv=2, remote_adv=6 → (6/1 - 2/1) / 2 = 2 (full window, all same)
+        let mut time_sync = TimeSync::default();
+        for i in 0..30 {
+            time_sync.advance_frame(i, 2, 6);
+        }
+        assert_eq!(time_sync.average_frame_advantage(), 2);
+    }
 }


### PR DESCRIPTION
## New unit tests added (34 total, up from 16)

### `frame_info.rs` — `PlayerInput` construction and equality
- `test_input_equality_frame_mismatch_not_input_only` — same input, different frames, `input_only=false` returns false
- `test_blank_input` — `blank_input()` produces zeroed input with the correct frame
- `test_new_stores_frame_and_input` — `new()` stores both frame and input correctly

### `input_queue.rs` — prediction, mismatch tracking, confirmed inputs, circular buffer
- `test_prediction_returned_for_missing_frame` — requesting an unavailable frame returns `InputStatus::Predicted`
- `test_prediction_repeats_last_input` — predicted input mirrors the last real input
- `test_confirmed_input_after_prediction_no_mismatch` — real input matching the prediction keeps `first_incorrect_frame` as `NULL_FRAME`
- `test_first_incorrect_frame_tracked_on_mismatch` — real input differing from prediction sets `first_incorrect_frame` correctly
- `test_reset_prediction_clears_state` — `reset_prediction()` clears `first_incorrect_frame` and `last_requested_frame`
- `test_confirmed_input_returns_correct_value` — `confirmed_input()` returns the exact stored input for a given frame
- `test_discard_confirmed_frames_reduces_length` — discarding confirmed frames shrinks the queue
- `test_queue_wraps_around_without_panic` — adding 200 frames with periodic discards exercises the circular index wraparound

### `time_sync.rs` — window semantics and averaging
- `test_window_wraparound_uses_only_recent_frames` — values older than the 30-frame window are overwritten and excluded from the average
- `test_partial_window_includes_zero_initialized_slots` — partially filled window correctly includes zero-initialized slots in the average
- `test_asymmetric_advantages` — verifies the `(remote_avg - local_avg) / 2` formula with non-symmetric values

### `compression.rs` — edge cases for delta + RLE codec
- `test_encode_decode_identical_to_reference` — inputs identical to the reference encode and decode correctly
- `test_encode_decode_single_input` — codec works with a single input
- `test_encode_decode_all_zeros` — all-zero reference and inputs roundtrip correctly
- `test_delta_encode_decode_in_isolation` — `delta_encode`/`delta_decode` tested independently from RLE

### `sync_layer.rs` — `GameStateCell`
- `test_cell_default_frame_is_null` — fresh cell reports `NULL_FRAME`
- `test_cell_save_and_frame` — `frame()` returns the saved frame number
- `test_cell_save_and_checksum` — `checksum()` returns the saved checksum
- `test_cell_data_returns_none_before_save` — `data()` returns `None` on a fresh cell
- `test_cell_data_returns_some_after_save` — `data()` returns the saved value without cloning
- `test_cell_load_clones_value` — `load()` returns a clone of the saved value
- `test_cell_clone_shares_state` — cloning a cell shares the underlying `Arc`; saves are visible through both handles

### `sync_layer.rs` — `SyncLayer`
- `test_advance_frame_increments_current_frame` — `advance_frame()` increments `current_frame`
- `test_save_current_state_updates_last_saved_frame` — `save_current_state()` updates `last_saved_frame`
- `test_saved_state_by_frame_returns_none_before_save` — querying an unsaved frame returns `None`
- `test_saved_state_by_frame_returns_some_after_save` — querying a saved frame returns `Some`
- `test_load_frame_rewinds_current_frame` — `load_frame()` rolls `current_frame` back to the loaded frame
- `test_check_simulation_consistency_no_mismatch` — no mismatches reported when predictions match real inputs
- `test_check_simulation_consistency_finds_mismatch` — earliest incorrect frame is detected and returned
- `test_set_last_confirmed_frame_updates_last_confirmed` — `last_confirmed_frame()` reflects the newly confirmed frame
- `test_set_last_confirmed_frame_sparse_saving_caps_at_last_saved` — with `sparse_saving=true`, confirmed frame is capped at `last_saved_frame`
- `test_disconnected_player_returns_default_input` — disconnected players yield `InputStatus::Disconnected` and a default input