### PR TITLE
test: integration tests

### DIFF
--- a/tests/stubs.rs
+++ b/tests/stubs.rs
@@ -105,6 +105,47 @@ impl RandomChecksumGameStub {
     }
 }
 
+/// A single-player game stub for tests that use `with_num_players(1)`.
+/// The `advance_frame` logic only reads `inputs[0]`.
+pub struct GameStub1P {
+    pub gs: StateStub,
+}
+
+impl GameStub1P {
+    #[allow(dead_code)]
+    pub fn new() -> GameStub1P {
+        GameStub1P {
+            gs: StateStub { frame: 0, state: 0 },
+        }
+    }
+
+    #[allow(dead_code)]
+    pub fn handle_requests(&mut self, requests: Vec<GgrsRequest<StubConfig>>) {
+        for request in requests {
+            match request {
+                GgrsRequest::LoadGameState { cell, .. } => self.load_game_state(cell),
+                GgrsRequest::SaveGameState { cell, frame } => self.save_game_state(cell, frame),
+                GgrsRequest::AdvanceFrame { inputs } => self.advance_frame(inputs),
+            }
+        }
+    }
+
+    fn save_game_state(&mut self, cell: GameStateCell<StateStub>, frame: Frame) {
+        assert_eq!(self.gs.frame, frame);
+        let checksum = calculate_hash(&self.gs);
+        cell.save(frame, Some(self.gs), Some(checksum as u128));
+    }
+
+    fn load_game_state(&mut self, cell: GameStateCell<StateStub>) {
+        self.gs = cell.load().unwrap();
+    }
+
+    fn advance_frame(&mut self, inputs: Vec<(StubInput, InputStatus)>) {
+        self.gs.state += inputs[0].0.inp as i32;
+        self.gs.frame += 1;
+    }
+}
+
 #[derive(Default, Copy, Clone, Hash)]
 pub struct StateStub {
     pub frame: i32,

--- a/tests/test_p2p_session.rs
+++ b/tests/test_p2p_session.rs
@@ -8,6 +8,40 @@ use serial_test::serial;
 use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 use stubs::{StubConfig, StubInput};
 
+fn make_session(
+    port: u16,
+    local: u16,
+    remote: u16,
+) -> (ggrs::P2PSession<StubConfig>, ggrs::P2PSession<StubConfig>) {
+    let addr1 = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), port);
+    let addr2 = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), remote);
+
+    let s1 = SessionBuilder::<StubConfig>::new()
+        .add_player(PlayerType::Local, 0)
+        .unwrap()
+        .add_player(PlayerType::Remote(addr2), 1)
+        .unwrap()
+        .start_p2p_session(UdpNonBlockingSocket::bind_to_port(local).unwrap())
+        .unwrap();
+    let s2 = SessionBuilder::<StubConfig>::new()
+        .add_player(PlayerType::Remote(addr1), 0)
+        .unwrap()
+        .add_player(PlayerType::Local, 1)
+        .unwrap()
+        .start_p2p_session(UdpNonBlockingSocket::bind_to_port(remote).unwrap())
+        .unwrap();
+    (s1, s2)
+}
+
+fn sync_sessions(s1: &mut ggrs::P2PSession<StubConfig>, s2: &mut ggrs::P2PSession<StubConfig>) {
+    for _ in 0..50 {
+        s1.poll_remote_clients();
+        s2.poll_remote_clients();
+    }
+    assert_eq!(s1.current_state(), SessionState::Running);
+    assert_eq!(s2.current_state(), SessionState::Running);
+}
+
 #[test]
 #[serial]
 fn test_add_more_players() -> Result<(), GgrsError> {
@@ -315,6 +349,176 @@ fn test_desyncs_and_input_delay_no_panic() -> Result<(), GgrsError> {
         stub1.handle_requests(requests1);
         stub2.handle_requests(requests2);
     }
+
+    Ok(())
+}
+
+// ── Builder validation ────────────────────────────────────────────────────────
+
+#[test]
+fn test_builder_duplicate_player_handle_errors() {
+    let remote_addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 8080);
+    let result = SessionBuilder::<StubConfig>::new()
+        .add_player(PlayerType::Local, 0)
+        .unwrap()
+        .add_player(PlayerType::Remote(remote_addr), 0); // duplicate handle
+    assert!(result.is_err());
+}
+
+#[test]
+fn test_builder_local_handle_out_of_range_errors() {
+    // handle 5 >= num_players(2) for a Local player → error
+    let result = SessionBuilder::<StubConfig>::new().add_player(PlayerType::Local, 5);
+    assert!(result.is_err());
+}
+
+#[test]
+fn test_builder_remote_handle_out_of_range_errors() {
+    let remote_addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 8080);
+    // handle 5 >= num_players(2) for a Remote player → error
+    let result = SessionBuilder::<StubConfig>::new().add_player(PlayerType::Remote(remote_addr), 5);
+    assert!(result.is_err());
+}
+
+#[test]
+fn test_builder_spectator_handle_below_num_players_errors() {
+    let spec_addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 9000);
+    // handle 0 < num_players(2) for a Spectator → error
+    let result =
+        SessionBuilder::<StubConfig>::new().add_player(PlayerType::Spectator(spec_addr), 0);
+    assert!(result.is_err());
+}
+
+#[test]
+#[serial]
+fn test_builder_missing_player_errors() {
+    let socket = UdpNonBlockingSocket::bind_to_port(7777).unwrap();
+    // num_players=2 but only player 0 registered
+    let result = SessionBuilder::<StubConfig>::new()
+        .add_player(PlayerType::Local, 0)
+        .unwrap()
+        .start_p2p_session(socket);
+    assert!(result.is_err());
+}
+
+#[test]
+fn test_builder_fps_zero_errors() {
+    let result = SessionBuilder::<StubConfig>::new().with_fps(0);
+    assert!(result.is_err());
+}
+
+// ── Session behaviour ─────────────────────────────────────────────────────────
+
+#[test]
+#[serial]
+fn test_synchronizing_events_emitted() -> Result<(), GgrsError> {
+    let (mut sess1, mut sess2) = make_session(7777, 7777, 8888);
+    sync_sessions(&mut sess1, &mut sess2);
+
+    let events1: Vec<_> = sess1.events().collect();
+    assert!(events1
+        .iter()
+        .any(|e| matches!(e, GgrsEvent::Synchronizing { .. })));
+    assert!(events1
+        .iter()
+        .any(|e| matches!(e, GgrsEvent::Synchronized { .. })));
+
+    let events2: Vec<_> = sess2.events().collect();
+    assert!(events2
+        .iter()
+        .any(|e| matches!(e, GgrsEvent::Synchronizing { .. })));
+    assert!(events2
+        .iter()
+        .any(|e| matches!(e, GgrsEvent::Synchronized { .. })));
+
+    Ok(())
+}
+
+#[test]
+#[serial]
+fn test_network_stats_invalid_handles() -> Result<(), GgrsError> {
+    let (mut sess1, mut sess2) = make_session(7777, 7777, 8888);
+    sync_sessions(&mut sess1, &mut sess2);
+
+    // invalid handle → error
+    assert!(sess1.network_stats(99).is_err());
+    // local player handle → error (no network stats for local players)
+    assert!(sess1.network_stats(0).is_err());
+    assert!(sess2.network_stats(1).is_err());
+
+    Ok(())
+}
+
+#[test]
+#[serial]
+fn test_game_state_converges() -> Result<(), GgrsError> {
+    let (mut sess1, mut sess2) = make_session(7777, 7777, 8888);
+    sync_sessions(&mut sess1, &mut sess2);
+
+    let mut stub1 = stubs::GameStub::new();
+    let mut stub2 = stubs::GameStub::new();
+
+    // use constant input so predictions always match — no mispredictions, fully deterministic
+    for _ in 0..50 {
+        sess1.poll_remote_clients();
+        sess2.poll_remote_clients();
+
+        sess1.add_local_input(0, StubInput { inp: 0 }).unwrap();
+        let requests1 = sess1.advance_frame().unwrap();
+        stub1.handle_requests(requests1);
+
+        sess2.add_local_input(1, StubInput { inp: 0 }).unwrap();
+        let requests2 = sess2.advance_frame().unwrap();
+        stub2.handle_requests(requests2);
+    }
+
+    // both sessions must reach the same game state
+    assert_eq!(stub1.gs.state, stub2.gs.state);
+    assert_eq!(stub1.gs.frame, stub2.gs.frame);
+
+    Ok(())
+}
+
+#[test]
+#[serial]
+fn test_desync_detection_off_by_default() -> Result<(), GgrsError> {
+    // Sessions created without calling with_desync_detection_mode → Off by default
+    let (mut sess1, mut sess2) = make_session(7777, 7777, 8888);
+    sync_sessions(&mut sess1, &mut sess2);
+
+    // drain sync events
+    let _ = sess1.events().count();
+    let _ = sess2.events().count();
+
+    let mut stub1 = stubs::GameStub::new();
+    let mut stub2 = stubs::GameStub::new();
+
+    for _ in 0..100 {
+        sess1.poll_remote_clients();
+        sess2.poll_remote_clients();
+
+        // corrupt sess1 state so checksums diverge
+        stub1.gs.state = 9999;
+
+        sess1.add_local_input(0, StubInput { inp: 0 }).unwrap();
+        sess2.add_local_input(1, StubInput { inp: 0 }).unwrap();
+
+        let requests1 = sess1.advance_frame().unwrap();
+        let requests2 = sess2.advance_frame().unwrap();
+
+        stub1.handle_requests(requests1);
+        stub2.handle_requests(requests2);
+    }
+
+    // with detection off, no DesyncDetected events should have been emitted
+    let events1: Vec<_> = sess1.events().collect();
+    let events2: Vec<_> = sess2.events().collect();
+    assert!(!events1
+        .iter()
+        .any(|e| matches!(e, GgrsEvent::DesyncDetected { .. })));
+    assert!(!events2
+        .iter()
+        .any(|e| matches!(e, GgrsEvent::DesyncDetected { .. })));
 
     Ok(())
 }

--- a/tests/test_p2p_spectator_session.rs
+++ b/tests/test_p2p_spectator_session.rs
@@ -1,9 +1,49 @@
 mod stubs;
 
-use ggrs::{GgrsError, PlayerType, SessionBuilder, SessionState, UdpNonBlockingSocket};
+use ggrs::{
+    GgrsError, GgrsRequest, PlayerType, SessionBuilder, SessionState, UdpNonBlockingSocket,
+};
 use serial_test::serial;
 use std::net::{IpAddr, Ipv4Addr, SocketAddr};
-use stubs::StubConfig;
+use stubs::{StubConfig, StubInput};
+
+/// Builds a synced host (1 local player + 1 spectator) and spectator session.
+fn make_host_and_spectator(
+    host_port: u16,
+    spec_port: u16,
+) -> Result<
+    (
+        ggrs::P2PSession<StubConfig>,
+        ggrs::SpectatorSession<StubConfig>,
+    ),
+    GgrsError,
+> {
+    let host_addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), host_port);
+    let spec_addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), spec_port);
+
+    let mut host_sess = SessionBuilder::<StubConfig>::new()
+        .with_num_players(1)
+        .add_player(PlayerType::Local, 0)?
+        .add_player(PlayerType::Spectator(spec_addr), 1)?
+        .start_p2p_session(UdpNonBlockingSocket::bind_to_port(host_port).unwrap())?;
+
+    let mut spec_sess = SessionBuilder::<StubConfig>::new()
+        .with_num_players(1)
+        .start_spectator_session(
+            host_addr,
+            UdpNonBlockingSocket::bind_to_port(spec_port).unwrap(),
+        );
+
+    for _ in 0..50 {
+        host_sess.poll_remote_clients();
+        spec_sess.poll_remote_clients();
+    }
+
+    assert_eq!(host_sess.current_state(), SessionState::Running);
+    assert_eq!(spec_sess.current_state(), SessionState::Running);
+
+    Ok((host_sess, spec_sess))
+}
 
 #[test]
 #[serial]
@@ -41,6 +81,106 @@ fn test_synchronize_with_host() -> Result<(), GgrsError> {
 
     assert_eq!(spec_sess.current_state(), SessionState::Running);
     assert_eq!(host_sess.current_state(), SessionState::Running);
+
+    Ok(())
+}
+
+#[test]
+#[serial]
+fn test_spectator_observes_frames() -> Result<(), GgrsError> {
+    let (mut host_sess, mut spec_sess) = make_host_and_spectator(7777, 8888)?;
+    let mut host_stub = stubs::GameStub1P::new();
+    let mut spec_stub = stubs::GameStub1P::new();
+
+    // The host sends confirmed inputs to spectators one frame late: confirmed_frame is computed
+    // before local inputs are registered in the same advance_frame call. So after host frame N,
+    // only inputs up to frame N-1 have been sent to the spectator. We drive 11 host frames and
+    // expect the spectator to be able to observe 10 of them.
+    for i in 0..11 {
+        host_sess.add_local_input(0, StubInput { inp: 1 }).unwrap();
+        let host_requests = host_sess.advance_frame().unwrap();
+        host_stub.handle_requests(host_requests);
+        // flush confirmed inputs (for frame i-1) to the spectator
+        host_sess.poll_remote_clients();
+
+        if i > 0 {
+            // inputs for frame i-1 are now available; spectator can advance
+            let spec_requests = spec_sess.advance_frame().unwrap();
+            assert!(
+                spec_requests
+                    .iter()
+                    .any(|r| matches!(r, GgrsRequest::AdvanceFrame { .. })),
+                "spectator should have received an AdvanceFrame request at iteration {i}"
+            );
+            spec_stub.handle_requests(spec_requests);
+        } else {
+            spec_sess.poll_remote_clients(); // receive packets but can't advance yet
+        }
+    }
+
+    assert_eq!(host_stub.gs.frame, 11);
+    assert_eq!(spec_stub.gs.frame, 10);
+
+    Ok(())
+}
+
+#[test]
+#[serial]
+fn test_spectator_catches_up_after_lag() -> Result<(), GgrsError> {
+    let host_addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 7777);
+    let spec_addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 8888);
+
+    let mut host_sess = SessionBuilder::<StubConfig>::new()
+        .with_num_players(1)
+        .add_player(PlayerType::Local, 0)?
+        .add_player(PlayerType::Spectator(spec_addr), 1)?
+        .start_p2p_session(UdpNonBlockingSocket::bind_to_port(7777).unwrap())?;
+
+    // catchup_speed=2 frames per advance_frame call when more than max_frames_behind=4 frames behind
+    let mut spec_sess = SessionBuilder::<StubConfig>::new()
+        .with_num_players(1)
+        .with_max_frames_behind(4)?
+        .with_catchup_speed(2)?
+        .start_spectator_session(host_addr, UdpNonBlockingSocket::bind_to_port(8888).unwrap());
+
+    for _ in 0..50 {
+        host_sess.poll_remote_clients();
+        spec_sess.poll_remote_clients();
+    }
+    assert_eq!(spec_sess.current_state(), SessionState::Running);
+
+    let mut host_stub = stubs::GameStub1P::new();
+
+    // host advances 6 frames; due to the 1-frame send lag, spectator receives inputs for
+    // frames 0-4 after 6 host advances → last_recv_frame=4, current_frame=-1 → 5 frames behind
+    for _ in 0..6 {
+        host_sess.add_local_input(0, StubInput { inp: 1 }).unwrap();
+        let requests = host_sess.advance_frame().unwrap();
+        host_stub.handle_requests(requests);
+        host_sess.poll_remote_clients(); // flush confirmed inputs to spectator socket
+        spec_sess.poll_remote_clients(); // receive packets (but don't advance)
+    }
+
+    // spectator should now be more than max_frames_behind=4 frames behind the host
+    assert!(
+        spec_sess.frames_behind_host() > 4,
+        "expected >4 behind, got {}",
+        spec_sess.frames_behind_host()
+    );
+
+    // one advance_frame call should advance 2 frames (catchup_speed=2)
+    let mut spec_stub = stubs::GameStub1P::new();
+    let requests = spec_sess.advance_frame().unwrap();
+    let advance_count = requests
+        .iter()
+        .filter(|r| matches!(r, GgrsRequest::AdvanceFrame { .. }))
+        .count();
+    assert_eq!(
+        advance_count, 2,
+        "spectator should catch up by 2 frames per step"
+    );
+    spec_stub.handle_requests(requests);
+    assert_eq!(spec_stub.gs.frame, 2);
 
     Ok(())
 }

--- a/tests/test_synctest_session.rs
+++ b/tests/test_synctest_session.rs
@@ -85,6 +85,93 @@ fn test_advance_frames_with_delayed_input() -> Result<(), GgrsError> {
 }
 
 #[test]
+fn test_create_session_single_player() -> Result<(), GgrsError> {
+    let mut stub = stubs::GameStub1P::new();
+    let mut sess = SessionBuilder::<StubConfig>::new()
+        .with_num_players(1)
+        .start_synctest_session()?;
+
+    for i in 0..20 {
+        sess.add_local_input(0, StubInput { inp: i })?;
+        let requests = sess.advance_frame()?;
+        stub.handle_requests(requests);
+        assert_eq!(stub.gs.frame, i as i32 + 1);
+    }
+
+    Ok(())
+}
+
+#[test]
+fn test_advance_frame_check_distance_one() -> Result<(), GgrsError> {
+    let check_distance = 1;
+    let mut stub = stubs::GameStub::new();
+    let mut sess = SessionBuilder::new()
+        .with_check_distance(check_distance)
+        .start_synctest_session()?;
+
+    for i in 0..20 {
+        sess.add_local_input(0, StubInput { inp: i as u32 })?;
+        sess.add_local_input(1, StubInput { inp: i as u32 })?;
+        let requests = sess.advance_frame()?;
+
+        if i <= check_distance {
+            // not yet far enough to trigger a rollback
+            assert_eq!(requests.len(), 2, "frame {i}: expected [Save, Advance]");
+            assert!(matches!(requests[0], GgrsRequest::SaveGameState { .. }));
+            assert!(matches!(requests[1], GgrsRequest::AdvanceFrame { .. }));
+        } else {
+            // rollback 1 frame + re-advance + save + advance
+            assert_eq!(
+                requests.len(),
+                4,
+                "frame {i}: expected [Load, Advance, Save, Advance]"
+            );
+            assert!(matches!(requests[0], GgrsRequest::LoadGameState { .. }));
+            assert!(matches!(requests[1], GgrsRequest::AdvanceFrame { .. }));
+            assert!(matches!(requests[2], GgrsRequest::SaveGameState { .. }));
+            assert!(matches!(requests[3], GgrsRequest::AdvanceFrame { .. }));
+        }
+
+        stub.handle_requests(requests);
+        assert_eq!(stub.gs.frame, i as i32 + 1);
+    }
+
+    Ok(())
+}
+
+#[test]
+fn test_state_is_deterministic() -> Result<(), GgrsError> {
+    // Two independent sessions with the same inputs must reach the same final state,
+    // verifying that save/load/advance is fully deterministic.
+    let mut stub_a = stubs::GameStub::new();
+    let mut sess_a = SessionBuilder::new()
+        .with_check_distance(2)
+        .start_synctest_session()?;
+
+    let mut stub_b = stubs::GameStub::new();
+    let mut sess_b = SessionBuilder::new()
+        .with_check_distance(2)
+        .start_synctest_session()?;
+
+    for i in 0..100u32 {
+        let inp = StubInput { inp: i % 7 }; // non-trivial pattern
+
+        sess_a.add_local_input(0, inp)?;
+        sess_a.add_local_input(1, inp)?;
+        stub_a.handle_requests(sess_a.advance_frame()?);
+
+        sess_b.add_local_input(0, inp)?;
+        sess_b.add_local_input(1, inp)?;
+        stub_b.handle_requests(sess_b.advance_frame()?);
+    }
+
+    assert_eq!(stub_a.gs.frame, stub_b.gs.frame);
+    assert_eq!(stub_a.gs.state, stub_b.gs.state);
+
+    Ok(())
+}
+
+#[test]
 #[should_panic]
 fn test_advance_frames_with_random_checksums() {
     let mut stub = stubs::RandomChecksumGameStub::new();


### PR DESCRIPTION
## New integration tests

### `tests/stubs.rs`
- Added `GameStub1P` — a single-player game stub for sessions with `with_num_players(1)`

### `tests/test_p2p_session.rs`

**Builder validation** (no network required):
- `test_builder_duplicate_player_handle_errors` — adding the same handle twice returns `Err`
- `test_builder_local_handle_out_of_range_errors` — local player handle ≥ `num_players` returns `Err`
- `test_builder_remote_handle_out_of_range_errors` — remote player handle ≥ `num_players` returns `Err`
- `test_builder_spectator_handle_below_num_players_errors` — spectator handle < `num_players` returns `Err`
- `test_builder_missing_player_errors` — `start_p2p_session` with incomplete player registration returns `Err`
- `test_builder_fps_zero_errors` — `with_fps(0)` returns `Err`

**Session behaviour:**
- `test_synchronizing_events_emitted` — both `Synchronizing` and `Synchronized` events are emitted for both peers during the handshake
- `test_network_stats_invalid_handles` — invalid handles and local-player handles return `Err` from `network_stats()`
- `test_game_state_converges` — both sessions reach identical `gs.state` after 50 frames of constant input
- `test_desync_detection_off_by_default` — intentionally corrupted state produces no `DesyncDetected` events when detection mode is `Off` (the default)

### `tests/test_synctest_session.rs`
- `test_create_session_single_player` — `with_num_players(1)` creates a valid session and advances frames correctly with one player
- `test_advance_frame_check_distance_one` — `check_distance=1` produces `[Save, Advance]` for the first two frames and `[Load, Advance, Save, Advance]` thereafter; validates the exact request sequence (previously only `check_distance=0` and `check_distance=2` were tested)
- `test_state_is_deterministic` — two independent sessions given identical inputs reach the same final `gs.state`, verifying save/load/advance determinism

### `tests/test_p2p_spectator_session.rs`
- `test_spectator_observes_frames` — after synchronization the spectator successfully receives and advances frames broadcast by the host; documents a protocol detail: confirmed inputs are sent to spectators one frame late, because `confirmed_frame` is computed before local inputs are registered in the same `advance_frame` call
- `test_spectator_catches_up_after_lag` — when the spectator falls more than `max_frames_behind` frames behind, a single `advance_frame` call advances `catchup_speed` frames instead of one
