### PR TITLE
Add Signs of Danger to projects using GGRS

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ GGRS has two demo apps — one written with [macroquad](https://github.com/not-f
 - [NES-bundler](https://github.com/tedsteen/nes-bundler)
 - [Girls with Swords](https://github.com/trian-gles/Girls-with-swords-GGRS) ([gameplay footage](https://youtu.be/TFJSpAqXtiI))
 - [NieR Automata: Online](https://git.yasupa.de/jasper3108/NAMS-mp) ([Youtube](https://www.youtube.com/@nieronline))
+- [Signs of Danger](https://store.steampowered.com/app/3816900/Signs_of_Danger/) ([devlog](https://www.slowrush.dev/), forked)
 
 ## Getting Started
 


### PR DESCRIPTION
Figured it might be nice to have my game on the list?

I noted `forked` because I am still running with some patches on ggrs and expect to diverge further (permanently) in the long run to add in-lib hot join[^hot-join] and input delay compensation[^compensation], so this saves me coming back later to raise a trivial PR to add the `forked` note then. But if you don't care about the distinction then feel free to remove it.

[^hot-join]: I have a design in mind where the lib basically gains a "now transfer the game state to remote player X" instruction that it can issue to the game. Then the lib instructs the joining-client to tick as fast as possible to catch up. So will feel like joining a Factorio game... hopefully. Haven't actually worked on it for about 15 months but in theory I think it's doable! :)

[^compensation]: basically: input delay of 3 ticks means your controls feel less responsive, which is no good for a platformer like my game. But what if the rendering thread (for each frame) advances past the current tick using the locally-received-but-delayed 3 ticks worth of inputs, renders that, then throws that away? I could skip expensive stuff like falling sand simulation, and get the best of both worlds. Seems promising in theory...