### PR TITLE
Fix rollback on caught-up player disconnect and add test

### DIFF
--- a/src/sessions/p2p_session.rs
+++ b/src/sessions/p2p_session.rs
@@ -760,7 +760,7 @@ impl<T: Config> P2PSession<T> {
                 }
                 endpoint.disconnect();
 
-                if self.sync_layer.current_frame() > last_frame {
+                if self.sync_layer.current_frame() > last_frame + 1 {
                     // remember to adjust simulation to account for the fact that the player disconnected a few frames ago,
                     // resimulating with correct disconnect flags (to account for user having some AI kick in).
                     self.disconnect_frame = last_frame + 1;

--- a/tests/test_p2p_session.rs
+++ b/tests/test_p2p_session.rs
@@ -1,8 +1,8 @@
 mod stubs;
 
 use ggrs::{
-    DesyncDetection, GgrsError, GgrsEvent, PlayerType, SessionBuilder, SessionState,
-    UdpNonBlockingSocket,
+    DesyncDetection, GgrsError, GgrsEvent, GgrsRequest, InputStatus, PlayerType, SessionBuilder,
+    SessionState, UdpNonBlockingSocket,
 };
 use instant::Duration;
 use serial_test::serial;
@@ -62,6 +62,28 @@ fn test_disconnect_player() -> Result<(), GgrsError> {
     assert!(sess.disconnect_player(1).is_err()); // already disconnected
     assert!(sess.disconnect_player(2).is_ok());
 
+    Ok(())
+}
+
+#[test]
+#[serial]
+fn test_caught_up_disconnect_does_not_rollback_to_current_frame() -> Result<(), GgrsError> {
+    let (mut session, mut peer) = stubs::make_p2p_sessions(7745, 7746);
+    stubs::sync_p2p_sessions(&mut session, &mut peer);
+
+    assert_eq!(session.current_frame(), 0);
+    session.disconnect_player(1)?;
+    session.add_local_input(0, StubInput { inp: 1 })?;
+    let requests = session.advance_frame()?;
+
+    assert!(requests
+        .iter()
+        .all(|request| !matches!(request, GgrsRequest::LoadGameState { .. })));
+    assert!(requests.iter().any(|request| matches!(
+        request,
+        GgrsRequest::AdvanceFrame { inputs }
+            if inputs[1].1 == InputStatus::Disconnected
+    )));
     Ok(())
 }
 


### PR DESCRIPTION
Fixes a panic when disconnecting a player whose inputs are fully caught up with the simulation. In this case, the first frame that should mark the player as disconnected is the current frame, which has not been simulated yet. GGRS incorrectly attempts to roll back to that same frame, violating its requirement that rollbacks target a frame strictly in the past.

The test synchronizes two players at frame zero, disconnects one before that frame is simulated, and advances the remaining session. It verifies that GGRS does not request a rollback to the current frame and instead simulates it normally with the departed player marked as disconnected.